### PR TITLE
Remove extraneous 'e' on except case

### DIFF
--- a/software/python/ayab/plugins/ayab_plugin/firmware_flash.py
+++ b/software/python/ayab/plugins/ayab_plugin/firmware_flash.py
@@ -154,7 +154,7 @@ class FirmwareFlash(QFrame):
         else:
           logging.info("Error on flashing firmware.")
           self.display_blocking_pop_up("Error on flashing firmware.", message_type="error")
-      except e:
+      except:
         logging.info("Error on flashing firmware.")
         self.display_blocking_pop_up("Error on flashing firmware.", message_type="error")
 


### PR DESCRIPTION
Can cause a crash with "NameError: global name 'e' is not defined"