### PR TITLE
Fix two windows that failed to open, bump version number

### DIFF
--- a/software/python/ayab/ayab.py
+++ b/software/python/ayab/ayab.py
@@ -349,7 +349,7 @@ class GuiMain(QMainWindow):
         self.__flash_ui.show()
 
     def open_about_ui(self):
-        self.__AboutForm = QtGui.QFrame()
+        self.__AboutForm = QtWidgets.QFrame()
         self.__about_ui = Ui_AboutForm()
         self.__about_ui.setupUi(self.__AboutForm)
         self.__AboutForm.show()
@@ -457,7 +457,7 @@ class GuiMain(QMainWindow):
         self.physical_width, self.physical_height = 0.0, 0.0
         self.ratio_tuple = 1.0, 1.0
         ratio = 0.0
-        dialog = QtGui.QDialog()
+        dialog = QtWidgets.QDialog()
         dialog.ui = smart_resize.Ui_Dialog()
         dialog.ui.setupUi(dialog)
 

--- a/software/python/ayab/ayab_about.py
+++ b/software/python/ayab/ayab_about.py
@@ -46,6 +46,6 @@ class Ui_AboutForm(object):
         AboutForm.setWindowTitle(_translate("AboutForm", "About AYAB"))
         self.label_2.setText(_translate("AboutForm", "All Yarns Are Beautiful"))
         self.label_4.setText(_translate("AboutForm", "<html><head/><body><p><a href=\"http://ayab-knitting.com\"><span style=\" text-decoration: underline; color:#0000ff;\">http://ayab-knitting.com</span></a></p></body></html>"))
-        self.label_3.setText(_translate("AboutForm", "Version 0.80"))
+        self.label_3.setText(_translate("AboutForm", "Version 0.90"))
 
 import resources_rc


### PR DESCRIPTION
Both the "smart resize" and the "about" window were failing to open. In
both cases, QtGui-> QtWidgets fixes the issue.

Also bump the version number display to 0.9, since this is the 0.9
branch.