### PR TITLE
fixes for Knit Progress window

### DIFF
--- a/src/main/python/ayab/ayab.py
+++ b/src/main/python/ayab/ayab.py
@@ -153,6 +153,9 @@ class GuiMain(QMainWindow):
 
     def updateProgress(self, row, total=0, repeats=0):
         '''Updates the Progress Bar.'''
+        if row < 0:
+            return
+
         # Store to local variable
         self.var_progress = row
         self.refresh_scene()

--- a/src/main/python/ayab/plugins/ayab_plugin/ayab_control.py
+++ b/src/main/python/ayab/plugins/ayab_plugin/ayab_control.py
@@ -179,7 +179,7 @@ class AYABControl(object):
         api = msg[1]
         log = f"API v{api}"
         if api >= 5:
-            log += ", FW v{msg[2]}.{msg[3]}"
+            log += f", FW v{msg[2]}.{msg[3]}"
         self.__logger.info(log)
         return
 
@@ -509,9 +509,6 @@ class AYABControl(object):
                     result = AYABControlKnitResult.DEVICE_NOT_READY
 
         elif self.__current_state == KnittingState.OPERATE:
-            if rcvMsg == "none":
-                print("quitting")
-                sys.exit()
             if rcvMsg == 'reqLine':
                 imageFinished = self.__cnfLine(rcvParam)
                 if imageFinished:

--- a/src/main/python/ayab/plugins/ayab_plugin/ayab_plugin.py
+++ b/src/main/python/ayab/plugins/ayab_plugin/ayab_plugin.py
@@ -32,6 +32,7 @@ from . import ayab_image
 from ayab.plugins.knitting_plugin import KnittingPlugin
 from .ayab_control import AYABControl, AYABControlKnitResult, KnittingMode
 
+from time import sleep
 
 class AyabPlugin(KnittingPlugin):
     def __init__(self):
@@ -43,7 +44,7 @@ class AyabPlugin(KnittingPlugin):
         self.__ayab_control.close()
 
     def onknit(self, e):
-        self.__logger.debug("called `ayab_plugin.onknit()`")
+        self.__logger.debug("callback to `ayab_plugin.onknit()`")
 
         self.__emit_reset_progress_window()
 
@@ -57,6 +58,8 @@ class AyabPlugin(KnittingPlugin):
                                          self.__ayab_control.get_row_multiplier())
             self.__knit_feedback_handler(result)
             if result is AYABControlKnitResult.FINISHED:
+                # allow time for signalUpdateKnitProgress to propagate
+                sleep(1)
                 break
         self.finish()
 
@@ -102,7 +105,7 @@ class AyabPlugin(KnittingPlugin):
         self.__emit_knitprogress(progress, row_multiplier)
 
     def onconfigure(self, e):
-        self.__logger.debug("called `ayab_plugin.onconfigure()`")
+        self.__logger.debug("callback to `ayab_plugin.onconfigure()`")
         parent_ui = self.__parent_ui
         conf = self.get_configuration_from_ui(parent_ui)
 
@@ -167,7 +170,7 @@ class AyabPlugin(KnittingPlugin):
         return True
 
     def onfinish(self, e):
-        self.__logger.debug("called `ayab_plugin.onfinish()`")
+        self.__logger.debug("callback to `ayab_plugin.onfinish()`")
         self.__logger.info("Finished Knitting.")
         self.__ayab_control.close()
         self.__parent_ui.resetUI()
@@ -177,7 +180,7 @@ class AyabPlugin(KnittingPlugin):
         self.__knitImage = False
 
     def onfail(self, e):
-        self.__logger.debug("called `ayab_plugin.onerror()`")
+        self.__logger.debug("callback to `ayab_plugin.onerror()`")
         # TODO add message info from event
         self.__logger.error("Error while knitting.")
         self.__ayab_control.close()

--- a/src/main/python/ayab/plugins/ayab_plugin/ayab_progress.py
+++ b/src/main/python/ayab/plugins/ayab_plugin/ayab_progress.py
@@ -31,18 +31,28 @@ class Progress:
         self.reset()
 
     def reset(self):
-        self.current_row = 0
-        self.total_rows = 0
+        self.current_row = -1
+        self.total_rows = -1
         self.repeats = -1
         self.colorSymbol = ""
         self.hall_l = 0
         self.hall_r = 0
         self.carriage_type = ""
         self.carriage_position = 0
-        self.lineNumber = 0
-        self.color = 0
+        self.lineNumber = -1
+        self.color = -1
         self.alt_color = None
         self.bits = bitarray()
+
+    def print(self):
+        print(self.current_row)
+        print(self.total_rows)
+        print(self.repeats)
+        print(self.colorSymbol)
+        print(self.lineNumber)
+        print(self.color)
+        print(self.alt_color)
+        print(self.bits)
 
     def get_carriage_info(self, msg):
         hall_l = int((msg[2] << 8) + msg[3])
@@ -92,43 +102,36 @@ class KnitProgress:
         self.container.close()
 
     def update(self, progress, row_multiplier):
-        if progress.lineNumber > self.row:
-            self.row += 1
-        if progress.lineNumber == self.row:
-            row, swipe = divmod(progress.lineNumber, row_multiplier)
-            if row < progress.total_rows or progress.repeats >= 0:
-                # row header on new line
-                direction = progress.lineNumber % 2
-                w0 = label("Row")
-                self.grid.addWidget(w0, progress.lineNumber, 0)
-                w1 = label(str(row + 1))
-                self.grid.addWidget(w1, progress.lineNumber, 1, 1, 1, Qt.AlignRight)
-                w2 = label("Pass " + str(swipe + 1))
-                self.grid.addWidget(w2, progress.lineNumber, 2)
-                if progress.colorSymbol == "":
-                    w3 = label("")
-                else:
-                    w3 = label("Color " + progress.colorSymbol)
-                    self.grid.addWidget(w3, progress.lineNumber, 3)
-                # TODO: report carriage
-                # w4 = label("KR") # progress.carriage
-                w4 = label(["\u2192 ","\u2190 "][direction])
-                self.grid.addWidget(w4, progress.lineNumber, 4)
-                # TODO: hints, notes, memos
-                w0.show()
-                w1.show()
-                w2.show()
-                w3.show()
-                w4.show()
-                self.area.ensureWidgetVisible(w0)
-            # graph line of stitches
-            for c in range(len(progress.bits)):
-                wc = stitch(progress.color, progress.bits[c], progress.alt_color)
-                self.grid.addWidget(wc, self.row, 6 + c)
-            # if not infinite repeats, update progress bar
-            # if progress.repeats < 0 and progress.total_rows > 0:  
-            #     self.pd.setValue(100 * (row + 1) / progress.total_rows)
-            # self.pd.update()
+        if progress.current_row < 0:
+            return
+        row, swipe = divmod(progress.lineNumber, row_multiplier)
+        direction = progress.lineNumber % 2
+        w0 = label("Row")
+        self.grid.addWidget(w0, progress.lineNumber, 0)
+        w1 = label(str(progress.current_row))
+        self.grid.addWidget(w1, progress.lineNumber, 1, 1, 1, Qt.AlignRight)
+        w2 = label("Pass " + str(swipe + 1))
+        self.grid.addWidget(w2, progress.lineNumber, 2)
+        if progress.colorSymbol == "":
+            w3 = label("")
+        else:
+            w3 = label("Color " + progress.colorSymbol)
+            self.grid.addWidget(w3, progress.lineNumber, 3)
+        # TODO: report carriage
+        # w4 = label("KR") # progress.carriage
+        w4 = label(["\u2192 ","\u2190 "][direction])
+        self.grid.addWidget(w4, progress.lineNumber, 4)
+        # TODO: hints, notes, memos
+        w0.show()
+        w1.show()
+        w2.show()
+        w3.show()
+        w4.show()
+        self.area.ensureWidgetVisible(w0)
+        # graph line of stitches
+        for c in range(len(progress.bits)):
+            wc = stitch(progress.color, progress.bits[c], progress.alt_color)
+            self.grid.addWidget(wc, progress.lineNumber, 6 + c)
         return
         
 

--- a/src/main/python/ayab/plugins/knitting_plugin.py
+++ b/src/main/python/ayab/plugins/knitting_plugin.py
@@ -87,7 +87,7 @@ class KnittingPlugin(Fysom):
     raise NotImplementedError(self.__NOT_IMPLEMENTED_ERROR.format("`get_configuration_from_ui`. It loads options with a given parent UI object."))
 
   def __init__(self, callbacks_dict):
-    self.__NOT_IMPLEMENTED_ERROR = "Classes that inherit from KnittingPlugin should implement {0}"
+    self.__NOT_IMPLEMENTED_ERROR = "Classes that inherit from `KnittingPlugin` should implement {0}"
 
     callbacks_dict = {
         'onconfigure': self.onconfigure,
@@ -104,7 +104,7 @@ class KnittingPlugin(Fysom):
              {'name': 'configure', 'src': 'error', 'dst': 'configured'},
              {'name': 'knit', 'src': 'configured', 'dst': 'knitting'},
              {'name': 'finish', 'src': 'knitting', 'dst': 'finished'},
-             {'name': 'fail', 'src': 'knitting', 'dst': 'error'}
+             {'name': 'fail', 'src': 'knitting', 'dst': 'error'},
          ],
          'callbacks':  callbacks_dict
          })


### PR DESCRIPTION
Fixes a bug in `AYABPlugin.onknit()`. The Qt signal `signalUpdateKnitProgress` needs to propagate before the `fysom` callback event `AYABPlugin.onknit()` in order for the last line of the pattern to print in the knit progress window. The race condition is still there, but a more satisfactory solution was reached by delaying the thread for one second after `signalUpdateKnitProgress`.