### PR TITLE
Trap type error for outdated preference settings

### DIFF
--- a/src/main/python/ayab/ayab_preferences.py
+++ b/src/main/python/ayab/ayab_preferences.py
@@ -84,7 +84,11 @@ class Preferences:
 
     def value(self, var):
         if var in self.settings.allKeys():
-            return self.convert(var)(self.settings.value(var))
+            try:
+                return self.convert(var)(self.settings.value(var))
+            except ValueError:
+                # saved setting is wrong type
+                return self.convert(var)()
         else:
             return self.default_value(var)
 


### PR DESCRIPTION
A small fix that smooths over when there is junk in the saved preferences, substituting a default value.