### PR TITLE
[#155] Fix scrolling of pattern when scrolling the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #208 GUI: Add sound effects at start, end, and new line
 * #145 GUI: Add feedback while flashing firmware
 * #131,#261 GUI: Add stretch and reflect image actions
+* #155 GUI: Fix scrolling of pattern when scrolling the sidebar
 
 ## 0.95 / 2019-01-28
 

--- a/src/main/python/ayab/ayab.py
+++ b/src/main/python/ayab/ayab.py
@@ -157,9 +157,6 @@ class GuiMain(QMainWindow):
             logging.info("Notification: " + text)
         self.ui.label_notifications.setText(text)
 
-    def wheelEvent(self, event):
-        self.scene.zoom = event
-
 
 class GenericThread(QThread):
     '''A generic thread wrapper for functions on threads.'''

--- a/src/main/python/ayab/scene.py
+++ b/src/main/python/ayab/scene.py
@@ -134,6 +134,10 @@ class Scene(QGraphicsView):
         self.__alignment = Alignment(alignment)
         self.refresh()
 
+    def wheelEvent(self, event):
+        '''Zoom the pattern upon mouse wheel event'''
+        self.zoom = event
+
     @property
     def zoom(self):
         return self.__zoom


### PR DESCRIPTION
Tested with latest version:
When scrolling the sidebar and hitting the bottom, the pattern is zoomed-out.
When scrolling the sidebar and hitting the top, the pattern is zoomed in.

This PR fixes this behavior. When scrolling over the pattern, the pattern is zoomed, when scrolling in the options-sidebar, only the sidebar is scrolled.