### PR TITLE
Add Direction class to GUI

### DIFF
--- a/src/main/python/ayab/engine/status.py
+++ b/src/main/python/ayab/engine/status.py
@@ -17,12 +17,39 @@
 #    Copyright 2014 Sebastian Oliva, Christian Obersteiner, Andreas Müller, Christian Gerbrandt
 #    https://github.com/AllYarnsAreBeautiful/ayab-desktop
 
+from enum import Enum, auto
 from bitarray import bitarray
 
 from PyQt5.QtCore import QCoreApplication
 from PyQt5.QtWidgets import QWidget
 
 from .status_gui import Ui_StatusWidget
+
+
+class Direction(Enum):
+    UNKNOWN = auto()
+    LEFT_TO_RIGHT = auto()
+    RIGHT_TO_LEFT = auto()
+
+    @property
+    def symbol(self):
+        if self == Direction.LEFT_TO_RIGHT:
+            return "\u2192 "
+        # else
+        if self == Direction.RIGHT_TO_LEFT:
+            return "\u2190 "
+        # else
+        return "  "
+
+    @property
+    def text(self):
+        if self == Direction.LEFT_TO_RIGHT:
+            return "Left to Right"
+        # else
+        if self == Direction.RIGHT_TO_LEFT:
+            return "Right to Left"
+        # else
+        return ""
 
 
 class Status(object):
@@ -52,6 +79,7 @@ class Status(object):
         self.hall_r = 0
         self.carriage_type = ""
         self.carriage_position = 0
+        self.direction = Direction.UNKNOWN
 
     def copy(self, status):
         self.active = status.active
@@ -67,6 +95,7 @@ class Status(object):
         self.hall_r = status.hall_r
         self.carriage_type = status.carriage_type
         self.carriage_position = status.carriage_position
+        self.direction = status.direction
 
     def parse_carriage_info(self, msg):
         if not (self.active):
@@ -93,6 +122,8 @@ class Status(object):
         self.hall_r = hall_r
         self.carriage_type = carriage_type
         self.carriage_position = carriage_position
+
+        # TODO: get carriage direction
 
 
 # FIXME translations for UI
@@ -122,3 +153,4 @@ class StatusTab(Status, QWidget):
         self.ui.label_hall_r.setText(str(status.hall_r))
         self.ui.slider_position.setValue(status.carriage_position)
         self.ui.label_carriage.setText(status.carriage_type)
+        self.ui.label_direction.setText(status.direction.text)

--- a/src/main/python/ayab/knitprogress.py
+++ b/src/main/python/ayab/knitprogress.py
@@ -22,6 +22,7 @@ from PyQt5.QtWidgets import QScrollArea, QGridLayout, QLayout, QLabel, QWidget
 from bitarray import bitarray
 
 from . import utils
+from .engine.status import Direction
 
 
 class KnitProgress(QScrollArea):
@@ -53,7 +54,6 @@ class KnitProgress(QScrollArea):
         # else
         tr_ = QCoreApplication.translate
         row, swipe = divmod(status.line_number, row_multiplier)
-        direction = status.line_number % 2
         # row
         w0 = self.__label(tr_("KnitProgress", "Row"))
         self.grid.addWidget(w0, status.line_number, 0)
@@ -74,7 +74,12 @@ class KnitProgress(QScrollArea):
             carriage = status.carriage[0] + status.carriage[2] + " "
         except Exception:
             carriage = ""
-        w4 = self.__label(carriage + ["\u2192 ", "\u2190 "][direction])
+        # direction = status.direction
+        if status.line_number % 2 == 0:
+            direction = Direction.LEFT_TO_RIGHT
+        else:
+            direction = Direction.RIGHT_TO_LEFT
+        w4 = self.__label(carriage + direction.symbol)
         self.grid.addWidget(w4, status.line_number, 4)
         # TODO: hints, notes, memos
         w0.show()


### PR DESCRIPTION
This new class helps prepare for being able to start the carriage on either the left or the right hand side of the needle bed (#247).

Direction is added as a field of the `Status` class and used to update the status tab and knit progress window.\

It is anticipated that the shield will report direction as part of the serial communication along with the other information about the carriage.