### PR TITLE
Changes from API v5 to API v6 and code annotations to help ensure backwards compatibility after API changes.

### DIFF
--- a/src/main/python/ayab/engine/status.py
+++ b/src/main/python/ayab/engine/status.py
@@ -97,9 +97,12 @@ class Status(object):
         self.carriage_position = status.carriage_position
         self.direction = status.direction
 
-    def parse_carriage_info(self, msg):
+    def parse_device_state_API6(self, state, msg):
         if not (self.active):
             return
+
+        # else
+        # TODO: if state != 1 report error and return
 
         # else
         hall_l = int((msg[2] << 8) + msg[3])

--- a/src/main/python/ayab/tests/test_communication.py
+++ b/src/main/python/ayab/tests/test_communication.py
@@ -28,8 +28,7 @@ from ayab.engine.communication import AyabCommunication, MessageToken
 
 class TestCommunication(unittest.TestCase):
     def setUp(self):
-        self.dummy_serial = serial.serial_for_url("loop://logging=debug",
-                                                  timeout=0.1)
+        self.dummy_serial = serial.serial_for_url("loop://logging=debug", timeout=0.1)
         self.comm_dummy = AyabCommunication(self.dummy_serial)
 
     def test_close_serial(self):
@@ -59,18 +58,18 @@ class TestCommunication(unittest.TestCase):
                                                 115200,
                                                 timeout=0.1)
 
-    def test_update(self):
+    def test_update_API6(self):
         byte_array = bytearray([0xc0, 0xc1, 0x01, 0xc0])
         self.dummy_serial.write(byte_array)
-        result = self.comm_dummy.update()
+        result = self.comm_dummy.update_API6()
         expected_result = (b'\xc1\x01', MessageToken.cnfStart, 1)
         assert result == expected_result
 
-    def test_req_start(self):
-        start_val, end_val, continuous_reporting = 0, 10, True
-        self.comm_dummy.req_start(start_val, end_val, continuous_reporting)
+    def test_req_start_API6(self):
+        machine_val, start_val, end_val, continuous_reporting, crc8 = 0, 0, 10, True, 0x74
+        self.comm_dummy.req_start_API6(machine_val, start_val, end_val, continuous_reporting)
         byte_array = bytearray(
-            [0xc0, 0x01, start_val, end_val, continuous_reporting, 0xc0])
+            [0xc0, 0x01, machine_val, start_val, end_val, continuous_reporting, crc8, 0xc0])
         bytes_read = self.dummy_serial.read(len(byte_array))
         self.assertEqual(bytes_read, byte_array)
 
@@ -80,22 +79,24 @@ class TestCommunication(unittest.TestCase):
         bytes_read = self.dummy_serial.read(len(byte_array))
         assert bytes_read == byte_array
 
-    def test_req_test(self):
-        self.comm_dummy.req_test()
+    def test_req_test_API6(self):
+        self.comm_dummy.req_test_API6()
         byte_array = bytearray([0xc0, 0x04, 0xc0])
         bytes_read = self.dummy_serial.read(len(byte_array))
         assert bytes_read == byte_array
 
-    def test_cnf_line(self):
+    def test_cnf_line_API6(self):
         line_number = 0
-        line_data = b'\0\xde\xad\xbe\xef\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0'
+        color = 0
         flags = 1
-        crc8 = 0xE9
-        self.comm_dummy.cnf_line(line_number, line_data, flags)
+        line_data = b'\xde\xad\xbe\xef\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0'
+        crc8 = 0xa7
+        self.comm_dummy.cnf_line_API6(line_number, color, flags, line_data)
         byte_array = bytearray([0xc0, 0x42])
         byte_array.append(line_number)
-        byte_array.extend(line_data)
+        byte_array.append(color)
         byte_array.append(flags)
+        byte_array.extend(line_data)
         byte_array.append(crc8)
         byte_array.append(0xc0)
         bytes_read = self.dummy_serial.read(len(byte_array))

--- a/src/main/python/ayab/tests/test_control.py
+++ b/src/main/python/ayab/tests/test_control.py
@@ -230,7 +230,7 @@ class TestKnitControl(unittest.TestCase):
         control.start_row = 1
         assert control.func(control, 12) == (0, 0, False, False)
 
-    def test_select_needles(self):
+    def test_select_needles_API6(self):
         control = KnitControl(self.parent)
         control.start(Machine(0))
         control.num_colors = 2
@@ -250,7 +250,7 @@ class TestKnitControl(unittest.TestCase):
         bits0.frombytes(
             b'\x00\x00\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
         )
-        assert control.select_needles(0, 0, False) == bits0
+        assert control.select_needles_API6(0, 0, False) == bits0
 
         # 40 pixel image set to the center
         pattern.alignment = Alignment.CENTER
@@ -259,20 +259,20 @@ class TestKnitControl(unittest.TestCase):
         bits1.frombytes(
             b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
         )
-        assert control.select_needles(0, 0, False) == bits1
+        assert control.select_needles_API6(0, 0, False) == bits1
 
         # 40 pixel image set in the center
         # blank line so central 40 pixels unset
         # flanking pixels set (2 different options)
         control.mode = KnitMode.CLASSIC_RIBBER
-        assert control.select_needles(2, 1, False) == ~bits1
+        assert control.select_needles_API6(2, 1, False) == ~bits1
         control.mode = KnitMode.MIDDLECOLORSTWICE_RIBBER
-        assert control.select_needles(2, 1, False) == ~bits1
+        assert control.select_needles_API6(2, 1, False) == ~bits1
 
         # image is wider than machine width
         # all pixels set
         control.pattern = Pattern(Image.new('P', (202, 1)), Machine(0), 2)
-        assert control.select_needles(0, 0, False) == bitarray([True] * Machine(0).width)
+        assert control.select_needles_API6(0, 0, False) == bitarray([True] * Machine(0).width)
 
     def test_row_multiplier(self):
         assert KnitMode.SINGLEBED.row_multiplier(2) == 1

--- a/src/main/python/ayab/tests/test_status.py
+++ b/src/main/python/ayab/tests/test_status.py
@@ -28,11 +28,11 @@ class TestStatus(unittest.TestCase):
     def setUp(self):
         pass
 
-    def test_parse_carriage_info(self):
+    def test_parse_device_state_API6(self):
         p = Status()
         p.active = True
         msg = [0, 1, 2, 3, 4, 5, 1, 7.9]
-        p.parse_carriage_info(msg)
+        p.parse_device_state_API6(1, msg)
         assert p.hall_l == 0x203
         assert p.hall_r == 0x405
         assert p.carriage_type == "K Carriage"


### PR DESCRIPTION
Added parameter to `req_start` method so that it specifies the machine in use. Also added CRC8 checksum.

Added device state parameter to method in `Status` class that parses carriage info so that error states can be evaluated.

Added color byte to `cnf_line` message and shortened needle data array to 15 bytes for KH-270 machines.

Incremented (minimum) required API version to 6.

Added annotations and renamed a bunch of methods with `_API6` suffix that are (potentially) specific to this API version.

Changes documented here: https://github.com/AllYarnsAreBeautiful/ayab-manual/pull/13/files#diff-96cc378dcdef180641176501f42183c7