### PR TITLE
Don't reorder the color histogram for singlebed mode

### DIFF
--- a/src/main/python/ayab/engine/control.py
+++ b/src/main/python/ayab/engine/control.py
@@ -69,7 +69,7 @@ class Control(Observable):
                 self.machine.width)
             self.start_pixel = self.start_needle - self.pattern.pat_start_needle
             self.end_pixel = self.end_needle - self.pattern.pat_start_needle
-            if self.FLANKING_NEEDLES:
+            if self.FLANKING_NEEDLES and self.mode != Mode.SINGLEBED:
                 self.midline = self.pattern.knit_end_needle - self.machine.width // 2
             else:
                 self.midline = self.end_needle - self.machine.width // 2
@@ -189,7 +189,7 @@ class Control(Observable):
         if self.mode != Mode.SINGLEBED:
             self.status.color_symbol = self.COLOR_SYMBOLS[color]
         self.status.color = self.pattern.palette[color]
-        if self.FLANKING_NEEDLES:
+        if self.FLANKING_NEEDLES and self.mode != Mode.SINGLEBED:
             self.status.bits = bits[self.pattern.knit_start_needle:self.
                                     pattern.knit_end_needle]
         else:
@@ -205,7 +205,7 @@ class Control(Observable):
 
         # select needles flanking the pattern
         # if necessary to knit the background color
-        if self.mode.flanking_needles(color, self.num_colors):
+        if self.mode.flanking_needles(color, self.num_colors) and self.mode != Mode.SINGLEBED:
             bits[0:self.start_needle] = True
             bits[self.end_needle:self.machine.width] = True
 

--- a/src/main/python/ayab/engine/engine.py
+++ b/src/main/python/ayab/engine/engine.py
@@ -123,7 +123,7 @@ class Engine(Observable, QDockWidget):
 
         # TODO: detect if previous conf had the same
         # image to avoid re-generating.
-        self.pattern = Pattern(image, self.config.machine,
+        self.pattern = Pattern(image, self.config,
                                self.config.num_colors)
 
         # validate configuration options

--- a/src/main/python/ayab/tests/README.md
+++ b/src/main/python/ayab/tests/README.md
@@ -1,0 +1,7 @@
+# To run tests
+
+From `src/main/python`
+
+Run:
+
+`python -m unittest ayab/tests/<name_of_test_file.py>`

--- a/src/main/python/ayab/tests/test_control.py
+++ b/src/main/python/ayab/tests/test_control.py
@@ -42,6 +42,11 @@ class Engine(object):
     def __init__(self):
         self.status = Status()
 
+class Config(object):
+    def __init__(self, machine, mode=Mode.SINGLEBED):
+        self.machine = machine
+        self.mode = mode
+
 
 class TestControl(unittest.TestCase):
     def setUp(self):
@@ -49,7 +54,7 @@ class TestControl(unittest.TestCase):
 
     def test__singlebed(self):
         control = Control(self.parent, self.parent.engine)
-        control.pattern = Pattern(Image.new('P', (1, 3)), Machine(0), 2)
+        control.pattern = Pattern(Image.new('P', (1, 3)), Config(Machine(0)), 2)
         control.num_colors = 2
         control.start_row = 0
         control.inf_repeat = False
@@ -66,7 +71,7 @@ class TestControl(unittest.TestCase):
 
     def test__classic_ribber_2col(self):
         control = Control(self.parent, self.parent.engine)
-        control.pattern = Pattern(Image.new('P', (1, 5)), Machine(0), 2)
+        control.pattern = Pattern(Image.new('P', (1, 5)), Config(Machine(0), Mode.CLASSIC_RIBBER), 2)
         control.num_colors = 2
         control.start_row = 0
         control.inf_repeat = False
@@ -93,7 +98,7 @@ class TestControl(unittest.TestCase):
 
     def test__classic_ribber_multicol(self):
         control = Control(self.parent, self.parent.engine)
-        control.pattern = Pattern(Image.new('P', (1, 3)), Machine(0), 3)
+        control.pattern = Pattern(Image.new('P', (1, 3)), Config(Machine(0), Mode.CLASSIC_RIBBER), 3)
         control.num_colors = 3
         control.start_row = 0
         control.inf_repeat = False
@@ -125,7 +130,7 @@ class TestControl(unittest.TestCase):
 
     def test__middlecolorstwice_ribber(self):
         control = Control(self.parent, self.parent.engine)
-        control.pattern = Pattern(Image.new('P', (1, 5)), Machine(0), 3)
+        control.pattern = Pattern(Image.new('P', (1, 5)), Config(Machine(0), Mode.MIDDLECOLORSTWICE_RIBBER), 3)
         control.mode = Mode.MIDDLECOLORSTWICE_RIBBER
         control.num_colors = 3
         control.start_row = 0
@@ -166,7 +171,7 @@ class TestControl(unittest.TestCase):
 
     def test__heartofpluto_ribber(self):
         control = Control(self.parent, self.parent.engine)
-        control.pattern = Pattern(Image.new('P', (1, 5)), Machine(0), 3)
+        control.pattern = Pattern(Image.new('P', (1, 5)), Config(Machine(0), Mode.HEARTOFPLUTO_RIBBER), 3)
         control.mode = Mode.HEARTOFPLUTO_RIBBER
         control.num_colors = 3
         control.start_row = 0
@@ -207,7 +212,7 @@ class TestControl(unittest.TestCase):
 
     def test__circular_ribber(self):
         control = Control(self.parent, self.parent.engine)
-        control.pattern = Pattern(Image.new('P', (1, 3)), Machine(0), 3)
+        control.pattern = Pattern(Image.new('P', (1, 3)), Config(Machine(0), Mode.CIRCULAR_RIBBER), 3)
         control.num_colors = 3
         control.start_row = 0
         control.inf_repeat = False
@@ -248,7 +253,7 @@ class TestControl(unittest.TestCase):
         im = Image.new('P', (40, 3), 0)
         im1 = Image.new('P', (40, 1), 1)
         im.paste(im1, (0, 0))
-        pattern = Pattern(im, Machine(0), 2)
+        pattern = Pattern(im, Config(Machine(0), Mode.SINGLEBED), 2)
         pattern.alignment = Alignment.LEFT
         control.pattern = pattern
         assert pattern.pat_start_needle == 160
@@ -259,7 +264,7 @@ class TestControl(unittest.TestCase):
         control.end_pixel = 40
         bits0 = bitarray()
         bits0.frombytes(
-            b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00'
+            b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
         )
         assert control.select_needles_API6(0, 0, False) == bits0
 


### PR DESCRIPTION
Bug: https://github.com/AllYarnsAreBeautiful/ayab-desktop/issues/442

Reordering the image colors causes problems with sparse images in single bed mode. 

Don't reorder the color histogram for singlebed mode but still map it down to [0:num_colors]

Also gets rid of the flanking needles in singlebed mode, they don't make sense there.

Includes updated tests.