### PR TITLE
Pin ubuntu to 20.04

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 
 jobs:
   run-pytest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6]


### PR DESCRIPTION
Similar to https://github.com/actions/setup-python/issues/544. ubuntu-latest does not provide a Python3.6 tarball nowadays, so we have to pin it to an older version.