### PR TITLE
#471 #467 Removing mega option, using /firmware directory level

### DIFF
--- a/src/main/python/ayab/firmware_flash.py
+++ b/src/main/python/ayab/firmware_flash.py
@@ -37,13 +37,11 @@ from . import utils
 class FirmwareFlash(QFrame):
     # Arduino devices and their `avrdude` names
     device_dict = {
-        "mega2560": "m2560",
         "uno": "atmega328p",
     }
     # Arduino programmers and their `avrdude` names
     programmer_dict = {
         "uno": "arduino",
-        "mega2560": "wiring",
     }
 
     def __init__(self, parent):
@@ -188,8 +186,7 @@ class FirmwareFlash(QFrame):
                 "ayab/firmware/avrdude_mac")
 
         binary_file = os.path.join(
-            self.__app_context.get_resource("ayab/firmware"), controller_name,
-            firmware_name)
+            self.__app_context.get_resource("ayab/firmware"), firmware_name)
         device = self.device_dict.get(controller_name)
         programmer = self.programmer_dict.get(controller_name, "wiring")
 

--- a/src/main/resources/base/ayab/firmware/firmware.json
+++ b/src/main/resources/base/ayab/firmware/firmware.json
@@ -4,14 +4,7 @@
             {
                 "url":"/",
                 "version":"1.0.0 (prototype)",
-                "file":"uno_0-95.hex"
-            }
-        ],
-        "mega2560":[
-            {
-                "url":"/",
-                "version":"1.0.0 (prototype)",
-                "file":"mega_1-0-0.hex"
+                "file":"ayab_monolithic_uno.hex"
             }
         ]
     }


### PR DESCRIPTION
solves #471 and #467

- Removing the mega option from the firmware.json
- Using `src/main/resources/base/ayab/firmware` as base folder for the firmware, as CI puts the firmware file there currently.