### PR TITLE
make DockWidget shorter

### DIFF
--- a/src/main/python/ayab/engine/dock_gui.ui
+++ b/src/main/python/ayab/engine/dock_gui.ui
@@ -14,7 +14,7 @@
      <x>0</x>
      <y>0</y>
      <width>240</width>
-     <height>581</height>
+     <height>506</height>
     </rect>
    </property>
    <property name="sizePolicy">
@@ -26,13 +26,13 @@
    <property name="minimumSize">
     <size>
      <width>240</width>
-     <height>581</height>
+     <height>506</height>
     </size>
    </property>
    <property name="maximumSize">
     <size>
      <width>260</width>
-     <height>581</height>
+     <height>506</height>
     </size>
    </property>
    <widget class="QWidget" name="ayab_config">

--- a/src/main/python/ayab/main_gui.ui
+++ b/src/main/python/ayab/main_gui.ui
@@ -150,7 +150,7 @@
               </property>
               <property name="sizeHint" stdset="0">
                <size>
-                <width>20</width>
+                <width>8</width>
                 <height>20</height>
                </size>
               </property>
@@ -179,7 +179,7 @@
               </property>
               <property name="sizeHint" stdset="0">
                <size>
-                <width>20</width>
+                <width>8</width>
                 <height>20</height>
                </size>
               </property>
@@ -211,21 +211,7 @@
            <property name="sizeConstraint">
             <enum>QLayout::SetMaximumSize</enum>
            </property>
-           <item>
-            <widget class="Line" name="line">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-            </widget>
-           </item>
           </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="Line" name="line_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
          </widget>
         </item>
         <item alignment="Qt::AlignHCenter">
@@ -239,7 +225,7 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <layout class="QVBoxLayout" name="vertical_layout_3">
+          <layout class="QHBoxLayout" name="layout_3">
            <property name="sizeConstraint">
             <enum>QLayout::SetMaximumSize</enum>
            </property>


### PR DESCRIPTION
Addressing #511

Also simplified the sidebar layout by removing horizontal lines, and aligning Knit and Cancel buttons horizontally instead of vertically.

To my eyes it looks better, especially in Windows.