### PR TITLE
fix hardware test operation

### DIFF
--- a/src/main/python/ayab/ayab.py
+++ b/src/main/python/ayab/ayab.py
@@ -136,19 +136,20 @@ class GuiMain(QMainWindow):
 
     def start_operation(self):
         """Disable UI elements at start of operation."""
-        self.menu.depopulate()
         self.ui.filename_lineedit.setEnabled(False)
         self.ui.load_file_button.setEnabled(False)
+        self.menu.setEnabled(False)
 
     def finish_operation(self, operation: Operation, beep: bool):
         """(Re-)enable UI elements after operation finishes."""
         if operation == Operation.KNIT:
-            self.knit_thread.terminate()
+            self.knit_thread.wait()
         else:
-            self.test_thread.terminate()
-        self.menu.repopulate()
+            # operation = Operation.TEST:
+            self.test_thread.wait()
         self.ui.filename_lineedit.setEnabled(True)
         self.ui.load_file_button.setEnabled(True)
+        self.menu.setEnabled(True)
         if operation == Operation.KNIT and beep:
             self.audio.play("finish")
 

--- a/src/main/python/ayab/engine/communication_mock.py
+++ b/src/main/python/ayab/engine/communication_mock.py
@@ -77,7 +77,7 @@ class CommunicationMock(Communication):
         indState = bytes(
             [Token.indState.value, 0, 0xFF, 0xFF, 0xFF, 0xFF, 1, 0x00, 1])
         self.rx_msg_list.append(indState)
- 
+
     def req_test_API6(self) -> None:
         """Send a request for hardware testing."""
         cnfTest = bytes([Token.cnfTest.value, 0])

--- a/src/main/python/ayab/engine/engine.py
+++ b/src/main/python/ayab/engine/engine.py
@@ -179,17 +179,14 @@ class Engine(SignalSender, QDockWidget):
                 self.emit_notification("Knitting canceled.")
                 self.__logger.info("Knitting canceled.")
             else:
+                # operation == Operation.TEST:
                 self.__logger.info("Finished knitting.")
             # small delay to finish printing to knit progress window
             # before "finish.wav" sound plays
             sleep(1)
         else:
             # TODO: provide translations for these messages
-            if self.__canceled:
-                self.emit_notification("Testing canceled.")
-                self.__logger.info("Testing canceled.")
-            else:
-                self.__logger.info("Finished testing.")
+            self.__logger.info("Finished testing.")
 
         # send signal to finish operation
         # "finish.wav" sound only plays if knitting was not canceled

--- a/src/main/python/ayab/engine/hw_test.py
+++ b/src/main/python/ayab/engine/hw_test.py
@@ -32,7 +32,7 @@ from .hw_test_communication_mock import HardwareTestCommunicationMock
 class HardwareTestDialog(QDialog):
     """Console for hardware tests."""
 
-    commands = ["help", "send", "beep", "read", "auto", "test", "quit"] 
+    commands = ["help", "send", "beep", "read", "auto", "test", "quit"]
 
     def __init__(self, parent):
         super().__init__()
@@ -111,6 +111,7 @@ class HardwareTestDialog(QDialog):
         token = getattr(Token, "quitCmd").value
         payload.append(token)
         self.__control.com.write_API6(payload)
+        self.__control.state = State.FINISHED
         # reset dialog
         self._auto_button.setChecked(False)
         self._test_button.setChecked(False)

--- a/src/main/python/ayab/engine/state.py
+++ b/src/main/python/ayab/engine/state.py
@@ -212,8 +212,12 @@ M
         return Output.NONE
 
     def _API6_run_test(control, operation):
-        # control.logger.debug("State RUN_TEST")
-        token, param = control.check_serial_API6()
+        control.logger.debug("State RUN_TEST")
+        while True:
+            token, param = control.check_serial_API6()
+            if token != Token.none:
+                break
+        control.logger.debug("Token " + token.name + ", param " + str(param))
         return Output.NONE
 
     def _API6_finished(control, operation):

--- a/src/main/python/ayab/fsm.py
+++ b/src/main/python/ayab/fsm.py
@@ -95,7 +95,6 @@ class FSM(object):
             lambda: parent.engine.knit_config(parent.scene.ayabimage.image))
         self.KNITTING.entered.connect(parent.start_knitting)
         self.TESTING.entered.connect(parent.start_testing)
-        self.TESTING_NO_IMAGE.entered.connect(parent.start_testing)
 
     def set_properties(self, parent):
         """

--- a/src/main/python/ayab/menu.py
+++ b/src/main/python/ayab/menu.py
@@ -46,10 +46,10 @@ class Menu(QMenuBar):
         except Exception:
             pass
         self.removeAction(self.ui.menu_tools.menuAction())
-
-    def repopulate(self):
         self.removeAction(self.ui.menu_preferences.menuAction())
         self.removeAction(self.ui.menu_help.menuAction())
+
+    def repopulate(self):
         self.addAction(self.ui.menu_image_actions.menuAction())
         self.setup()
 

--- a/src/main/python/ayab/thread.py
+++ b/src/main/python/ayab/thread.py
@@ -29,7 +29,6 @@ class GenericThread(QThread):
         self.kwargs = kwargs
 
     def __del__(self):
-        #self.join()
         self.wait()
 
     def run(self):


### PR DESCRIPTION
Addressing #461.

Fixes the following glitches:
- remain in state RUN_TEST until there is a valid token
- threads wait() instead of terminate()
- return to GUI thread after testing
- correct visibility of menu items before and after testing, and during knitting

Tested working on Windows 11 and Ubuntu 22.04.