### PR TITLE
Change output to request_start to have the knit instructions displayed

### DIFF
--- a/src/main/python/ayab/engine/engine_fsm.py
+++ b/src/main/python/ayab/engine/engine_fsm.py
@@ -118,7 +118,7 @@ M
                     # operation = Operation.KNIT:
                     control.state = State.REQUEST_START
                     control.logger.debug("State REQUEST_START")
-                    return Output.WAIT_FOR_INIT
+                    return Output.NONE
             else:
                 control.logger.error("Error initializing firmware: " + str(param))
                 return Output.ERROR_INITIALIZING_FIRMWARE
@@ -147,7 +147,7 @@ M
                 control.logger.debug("Knit init failed with error code " +
                                      str(param) + " in state " + str(control.status.firmware_state))
                 # TODO: more output to describe error
-        return Output.NONE
+        return Output.WAIT_FOR_INIT
 
     def _API6_confirm_start(control, operation):
         token, param = control.check_serial_API6()


### PR DESCRIPTION
This it to have the instructions "Please start machine. (Set the carriage to mode KC-I or KC-II and move the carriage over the left turn mark)." displayed after pressing the "Knit"button.  Currently they just flash quickly on the screen