### PR TITLE
Semantic versioning

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -61,7 +61,9 @@ jobs:
     - name: Set PACKAGE_VERSION
       run: |
         echo ${{ steps.vars.outputs.tag }} > src/main/resources/base/ayab/package_version
-        sed -i 's/PACKAGE_VERSION/${{steps.vars.outputs.tag}}/' src/build/settings/base.json
+        # remove suffix from semver tag, as fbs does not support them
+        version_without_suffix=$(echo ${{ steps.vars.outputs.tag }} | sed -E 's/^(v?[0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
+        sed -i 's/PACKAGE_VERSION/$version_without_suffix/' src/build/settings/base.json
         cat src/main/resources/base/ayab/package_version
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -191,7 +193,9 @@ jobs:
       shell: bash
       run: |
         echo ${{steps.vars.outputs.tag}} > src/main/resources/base/ayab/package_version
-        sed -i 's/PACKAGE_VERSION/${{steps.vars.outputs.tag}}/' src/build/settings/base.json
+        # remove suffix from semver tag, as fbs does not support them
+        version_without_suffix=$(echo ${{ steps.vars.outputs.tag }} | sed -E 's/^(v?[0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
+        sed -i 's/PACKAGE_VERSION/$version_without_suffix/' src/build/settings/base.json
         cat src/main/resources/base/ayab/package_version
     - name: Set up Python ${{ matrix.python-version }}
       id: py
@@ -327,7 +331,9 @@ jobs:
     - name: Set PACKAGE_VERSION
       run: |
         echo ${{steps.vars.outputs.tag}} > src/main/resources/base/ayab/package_version
-        sed -i'' -e 's/PACKAGE_VERSION/${{steps.vars.outputs.tag}}/' src/build/settings/base.json
+        # remove suffix from semver tag, as fbs does not support them
+        version_without_suffix=$(echo ${{ steps.vars.outputs.tag }} | sed -E 's/^(v?[0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
+        sed -i 's/PACKAGE_VERSION/$version_without_suffix/' src/build/settings/base.json
         cat src/main/resources/base/ayab/package_version
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -436,7 +442,9 @@ jobs:
       run: |
         cd git
         echo ${{steps.vars.outputs.tag}} > src/main/resources/base/ayab/package_version
-        sed -i 's/PACKAGE_VERSION/${{steps.vars.outputs.tag}}/' src/build/settings/base.json
+        # remove suffix from semver tag, as fbs does not support them
+        version_without_suffix=$(echo ${{ steps.vars.outputs.tag }} | sed -E 's/^(v?[0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
+        sed -i 's/PACKAGE_VERSION/$version_without_suffix/' src/build/settings/base.json
         cat src/main/resources/base/ayab/package_version
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 1.0.0 / Unreleased
 
+Change in versioning scheme: From now on, the AYAB desktop software and firmware are using the Semantic Versioning 2.0.0 (https://semver.org/) versioning scheme.
+Pre-releases are marked with a suffix, e.g. `1.0.0-rc1`, which stands for "release candidate 1"
+
 * #467 Devops: Drop support for Arduino Mega
 * #466 Devops: Bundle firmware for desktop application based on a manifest file
 * #464 Devops: Patch python module fbs to fix Windows installer bug 


### PR DESCRIPTION
Desktop-software related:
- [x] Strip suffix from semver tag before writing version to fbs' base.json as fbs does not support suffixes (see discussion https://github.com/AllYarnsAreBeautiful/ayab-desktop/issues/534#issuecomment-1622452529)
- [x] Add information to CHANGELOG about the switch to semver 2.0
- [x] Check if update notification (shown on startup) needs to be changed (see https://github.com/AllYarnsAreBeautiful/ayab-desktop/pull/551#issuecomment-1646272804)

Firmware-related:
- [x] Update Github workflow in Desktop repo to download the correct firmware binary according to the manifest file with an arbitrary release name in it (currently, it requires 'v' or 'test' as prefix) - solved with #552 
- [x] Check if firmware dialogue has to be altered to show firmware version correctly (esp. in case it contains a suffix)