### PR TITLE
bump PyQt5 to version 5.15.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fbs @ git+https://github.com/AllYarnsAreBeautiful/fbs@1.2.1-py38
-PyQt5==5.12.3
+PyQt5==5.15.10
 PyInstaller==4.4
 Pillow==7.1.2
 pyserial==3.4


### PR DESCRIPTION
Not immediately necessary, but the upgrade seems to work on Windows.