### PR TITLE
Update A Ton Of Dependencies To Fix Mac Releases

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -21,10 +21,10 @@ on:
 jobs:
   setup:
     name: Create cache
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.11]
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -76,18 +76,18 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.build.txt') }}
     - name: Install Python modules
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools
-        python -m pip install -r requirements.txt
+        python -m pip install -r requirements.build.txt
     - name: Cache Python modules
       if:   steps.pip-cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v3
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.build.txt') }}
     - name: Use cached gui files (1)
       id:   gui1-cache
       uses: actions/cache@v3
@@ -131,8 +131,8 @@ jobs:
                 (steps.e-cache.outputs.cache-hit    != 'true') ||
                 (steps.qm-cache.outputs.cache-hit   != 'true') }}
       run: |
-        sudo apt install -y qt5-default qttools5-dev-tools
-        bash setup-environment.ps1
+        sudo apt install -y qt6-base-dev qt6-tools-dev-tools qt6-l10n-tools
+        PATH=/usr/lib/qt6/bin:$PATH bash setup-environment.ps1
     - name: Cache gui files (1)
       if:   ${{ (steps.gui1-cache.outputs.cache-hit != 'true') }}
       uses: actions/cache/save@v3
@@ -172,7 +172,7 @@ jobs:
 
   deploy:
     name: Create and deploy source code documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -199,7 +199,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.11]
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -225,7 +225,7 @@ jobs:
         choco install vcredist-all # fixes dependency on msvcr100.dll
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools
-        python -m pip install -r requirements.txt
+        python -m pip install -r requirements.build.txt
         python -m pip install -r windows-build\windows_build_requirements.txt
     - name: Restore cached firmware
       id:   firmware-cache
@@ -335,10 +335,10 @@ jobs:
   build-macos:
     name: Create and upload Mac OSX release
     needs: setup
-    runs-on: macos-latest
+    runs-on: macos-14
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.11]
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -356,11 +356,20 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
+      shell: zsh {0}
       run: |
         brew install avrdude
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools
-        python -m pip install -r requirements.txt
+        brew install qt
+        python -m pip install delocate
+        python -m pip download --only-binary=:all: --platform macosx_10_09_x86_64 numpy==1.26.4
+        python -m pip download --only-binary=:all: --platform macosx_11_0_arm64 numpy==1.26.4
+        mkdir tmp-wheel/
+        delocate-fuse numpy*arm* numpy*x86* -w tmp-wheel/
+        python -m pip download --only-binary=:all: --platform macosx_10_10_x86_64 Pillow==10.0.0
+        python -m pip download --only-binary=:all: --platform macosx_11_0_arm64 Pillow==10.0.0
+        delocate-fuse Pillow*arm* Pillow*x86* -w tmp-wheel/
+        python -m pip install tmp-wheel/*.whl
+        python -m pip install --no-binary charset_normalizer -r requirements.build.txt
     - name: Restore cached firmware
       id:   firmware-cache
       uses: actions/cache@v3
@@ -421,10 +430,13 @@ jobs:
         ls -l src/main/python/ayab/
         ls -l src/main/resources/base/ayab/translations/
     - name: Build app
-      run: python -m fbs freeze --debug
+      run: |
+        python -m fbs freeze --debug
+        codesign -s - --force --all-architectures --timestamp --deep ./target/AYAB-mac.app
     - name: Create installer
       run: |
         python -m fbs installer
+        codesign -s - --force --all-architectures --timestamp --deep ./target/AYAB.dmg
         mv target/AYAB.dmg target/AYAB-${{ steps.vars.outputs.tag }}.dmg
     - name: Upload asset
       uses: ncipollo/release-action@v1
@@ -449,10 +461,10 @@ jobs:
   build-appimage:
     name: Create and upload Linux AppImage release
     needs: setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.11]
     steps:
     - name: Checkout repo into AppDir
       uses: actions/checkout@v3
@@ -468,7 +480,7 @@ jobs:
         echo "tag=$(git describe --tags)" >> $GITHUB_OUTPUT
         echo "python=python${{matrix.python-version}}" >> $GITHUB_OUTPUT
         echo "manifest=$(cat src/main/resources/base/ayab/firmware/manifest.txt)" >> $GITHUB_OUTPUT
-        echo "python-appimage=python${{matrix.python-version}}.18-cp38-cp38-manylinux2014_x86_64.AppImage" >> $GITHUB_OUTPUT
+        echo "python-appimage=python${{matrix.python-version}}.8-cp311-cp311-manylinux_2_28_x86_64.AppImage" >> $GITHUB_OUTPUT
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -489,7 +501,7 @@ jobs:
         ./AppRun -m pip install --upgrade setuptools
         # hack to fix setup.py script with faulty include
         ./AppRun -m pip install --global-option=build_ext --global-option="-I$(pwd)/opt/${{steps.vars.outputs.python}}/include/${{steps.vars.outputs.python}}" simpleaudio
-        ./AppRun -m pip install -r requirements.txt
+        ./AppRun -m pip install -r requirements.build.txt
     - name: Add AppDir subdirectories to PATH
       run: |
         echo "usr/bin" >> $GITHUB_PATH

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -7,10 +7,10 @@ on: [push, pull_request]
 
 jobs:
   run-pytest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.11]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install -y libasound2-dev qt5-default qttools5-dev-tools
+        sudo apt install -y libasound2-dev qt6-base-dev qt6-tools-dev-tools
         pip install --upgrade pip
         pip install --upgrade setuptools
         pip install flake8 pytest
@@ -46,3 +46,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: pytest -v
+      

--- a/README.md
+++ b/README.md
@@ -7,157 +7,129 @@ For information on how to install the release version of the software, see
 
 ## Running from Source & Development
 
-The AYAB desktop software runs using Python 3.8. This is not the current
-version of Python, so it is recommended to install the software to a
-virtual environment. Miniconda provides a virtual environment that is
-platform-independent and easy to use: download the lastest version from
-https://docs.conda.io/en/latest/miniconda.html and follow the installation
-instructions for your operating system.
-
-The Python module dependencies can be found in *requirements.txt*.
+The AYAB desktop software runs using Python 3.11.  
+The Python module dependencies are split across **runtime dependencies**, which are in *requirements.build.txt* and **development dependencies**, found in *requirements.txt*.
 
 This repository uses [pre-commit](https://pre-commit.com/) hooks.
-After cloning the repo and installing the requirements, you should run
+After cloning the repo and installing the development dependencies, you should run
 `pre-commit install` to set up the git hook scripts.
+### Platform-Specific Setup
+<details>
+    <summary>
+        Linux
+    </summary>
 
-### Linux
-
-For flashing the firmware, avrdude has to be available on your system.
-To be able to work on GUI elements and translation files, the Qt Dev tools are
-needed also.
-
+For flashing the firmware, avrdude has to be available on your system.  
+To be able to work on GUI elements and translation files, you will also need Qt Dev & Localization Tools.
 #### Debian/Ubuntu
-
-    sudo apt-get install python3-pip python3-dev python3-virtualenv python3-gi
-    sudo apt-get install libasound2-dev avrdude qttools5-dev-tools
-
-#### For openSUSE
-
-    sudo zypper install python3-pip python3-virtualenv python3-gi
-    sudo zypper install libasound avrdude qttools5-dev-tools
-
+```bash
+    sudo apt install python3.11 python3.11-dev python3.11-venv
+    sudo apt install libasound2-dev avrdude qt6-tools-dev-tools build-essential qt6-l10n-tools
+    export PATH=/usr/lib/qt6/bin:$PATH
+```
+#### openSUSE
+```bash
+    sudo zypper install python311 python311-pip python311-virtualenv python311-devel
+    sudo zypper install libasound2 alsa-devel avrdude qt6-tools qt6-tools-linguist
+    export PATH=/usr/lib/qt6/bin:$PATH 
+```
 #### All Distributions
 
 To be able to communicate with your Arduino, it might be necessary to add the
 rights for USB communication by adding your user to some groups.
-
+```bash
     sudo usermod -aG tty [userName]
     sudo usermod -aG dialout [userName]
+```
+</details>
 
-To install the development version you can checkout the git repository.
-
-    git clone https://github.com/AllYarnsAreBeautiful/ayab-desktop
-    cd ayab-desktop
-
-Create a virtual environment for AYAB:
-
-    conda create --name ayab -c conda-forge python=3.8 pip
-
-Now activate the virtual environment. The command prompt should now display
-`(ayab)` at the beginning of each line.
-
-    conda activate ayab
-
-Install the remaining prerequisites.
-
-    python -m pip install --upgrade pip
-    pip install --upgrade setuptools
-    pip install --ignore-installed -r requirements.txt
-    bash setup-environment.ps1
-
-Now start AYAB with
-
-    fbs run
-
-### Windows
+<details>
+    <summary>
+        Windows
+    </summary>
 
 Run Anaconda Powershell as administrator and install git.
-
+```ps
     conda install git
-
+```
 Now you can download the git repository with:
-
+```ps
     git clone https://github.com/AllYarnsAreBeautiful/ayab-desktop
     cd ayab-desktop
-
+```
 Next, create a virtual environment for AYAB:
-
-    conda create --name ayab -c conda-forge python=3.8 pip
-
+```ps
+    conda create --name ayab -c conda-forge python=3.11 pip
+```
 Activate the virtual environment. The command prompt should now display
 `(ayab)` at the beginning of each line.
-
+```ps
     conda activate ayab
+```
+(You may skip the virtual environment setup below.)
 
-Install the prerequisite Python modules.
-
-    python -m pip install --upgrade pip
-    pip install --upgrade setuptools
-    pip install --ignore-installed -r requirements.txt
-
-To be able to work on GUI elements and translation files, the Qt Dev tools are needed.
+To be able to work on GUI elements and translation files, the Qt Dev tools are needed.  
 Navigate to https://www.qt.io/download in a web browser and follow the installation
-instructions. From the available options, select "Custom install" and then "Qt 5.15.2".
-Then convert the PyQt5 `.ui` files and generate the translation files:
+instructions. From the available options, select "Custom install" and then "Qt 6.6.1".
+</details>
 
-    .\setup-environment.ps1
-
-Now start AYAB with:
-
-    fbs run
-
-### macOS
-
-*If on Apple Silicon (M1 & M2 chips)*
-
-* You will need to install the virtual environment using the x86_64 versions of packages due to the requirement of Python 3.8 (which has no build in Conda due to it predating Apple silicon). In order to do this, you need to set the terminal to fetch packages built for x86_64 architectures rather than the native arm64. In Applications, go to the Utilities folder and right click on the Terminal app, and choosing `Get Info`. Select the `Open using Rosetta` checkbox and close the window. Check that the change has taken place by opening the terminal and entering the command `arch`. This should return `i386` if everything went correctly.
-* Installing both native and rosetta versions of packages can cause conflicts. You can remove conflicting packages from homebrew by specifying architecture and using the remove command: `arch=arm64 brew remove xyz`.
+<details>
+<summary>
+macOS
+</summary>
 
 You can install Git using Homebrew:
-
+```bash
     brew install git
-
+```
 You will also need the Xcode command line tools:
-
+```bash
     xcode-select --install
+```
+To be able to work on GUI elements and translation files, the Qt Dev tools are needed also:
+```bash
+    brew install qt
+```
+Install python from [the official universal2 installer](https://www.python.org/ftp/python/3.11.8/python-3.11.8-macos11.pkg). (Conda does not produce universal binaries)  
 
-Next download the git repository:
+If you encounter the pip `SSL:TLSV1_ALERT_PROTOCOL_VERSION` problem:
+```bash
+    curl https://bootstrap.pypa.io/get-pip.py | python
+```
+</details>
 
+### Universal Setup Steps
+Once platform-specific setup is complete, download the git repository:
+```bash
     git clone https://github.com/AllYarnsAreBeautiful/ayab-desktop
     cd ayab-desktop
-
+```
 Create a virtual environment for AYAB:
-
-    conda create --name ayab -c conda-forge python=3.8 pip
-
+```bash
+    python3.11 -m venv .venv 
+```
 Now activate the virtual environment. The command prompt should now display
-`(ayab)` at the beginning of each line.
-
-    conda activate ayab
-
-Then install the remaining prerequisites with:
-
+`(.venv)` at the beginning of each line.
+```bash
+    source .venv/bin/activate
+```
+Install the remaining prerequisites with:
+```bash
     python -m pip install --upgrade pip
     pip install --upgrade setuptools
     pip install -r requirements.txt
+```
 
-To solve pip SSL:TLSV1_ALERT_PROTOCOL_VERSION problem:
+Next, convert the PySide6 `.ui` files and generate the translation files:
+```bash
+    bash ./setup-environment.ps1
+```
+If you get errors about missing `lrelease`, you can skip this (if you do not need the translation files). To do so, comment out lines [23:26] of `setup-environment.ps1`.
 
-    curl https://bootstrap.pypa.io/get-pip.py | python
-
-To be able to work on GUI elements and translation files, the Qt Dev tools are needed also:
-
-    https://download.qt.io/archive/qt/5.12/5.12.12/qt-opensource-mac-x64-5.12.12.dmg
-
-Finally, convert the PyQt5 `.ui` files and generate the translation files:
-
-    ./setup-environment.ps1
-
-If you get errors about missing `lrelease`, you can skip this if you do not need the translation files. To do so, comment out lines [23:26] of `setup-environment.ps1`.
-
-Now start AYAB with
-
+Finally, you can start AYAB with
+```bash
     fbs run
+```
 
 ## CI/CD on GitHub
 

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -1,0 +1,12 @@
+fbs @ git+https://github.com/AllYarnsAreBeautiful/fbs@1.2.1-pyqt6
+PySide6==6.6.1
+PyInstaller==6.4.0
+Pillow==10
+pyserial==3.5
+sliplib==0.6.2
+bitarray-hardbyte==2.3.8
+simpleaudio==1.0.4
+wave==0.0.2
+numpy==1.26.4
+charset-normalizer<3.0.0
+requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,4 @@
-fbs @ git+https://github.com/AllYarnsAreBeautiful/fbs@1.2.1-py38
-PyQt5==5.15.10
-PyInstaller==4.4
-Pillow==7.1.2
-pyserial==3.4
-sliplib==0.4.0
-pytest==5.4.1
+-r requirements.build.txt
+pytest==7.4.2
 mock==3.0.5
-bitarray-hardbyte==1.1.0
-simpleaudio==1.0.4
-wave==0.0.2
-numpy
-requests
-pre-commit
+pre-commit==3.6.2

--- a/setup-environment.ps1
+++ b/setup-environment.ps1
@@ -6,21 +6,21 @@
 
 git submodule update --init --recursive
 
-# convert PyQt5 `.ui` files to Python code
-pyuic5 src/main/python/ayab/about_gui.ui -o src/main/python/ayab/about_gui.py
-pyuic5 src/main/python/ayab/firmware_flash_gui.ui -o src/main/python/ayab/firmware_flash_gui.py
-pyuic5 src/main/python/ayab/main_gui.ui -o src/main/python/ayab/main_gui.py
-pyuic5 src/main/python/ayab/menu_gui.ui -o src/main/python/ayab/menu_gui.py
-pyuic5 src/main/python/ayab/mirrors_gui.ui -o src/main/python/ayab/mirrors_gui.py
-pyuic5 src/main/python/ayab/prefs_gui.ui -o src/main/python/ayab/prefs_gui.py
-pyuic5 src/main/python/ayab/engine/dock_gui.ui -o src/main/python/ayab/engine/dock_gui.py
-pyuic5 src/main/python/ayab/engine/options_gui.ui -o src/main/python/ayab/engine/options_gui.py
-pyuic5 src/main/python/ayab/engine/status_gui.ui -o src/main/python/ayab/engine/status_gui.py
+# convert Qt `.ui` files to Python code
+pyside6-uic src/main/python/ayab/about_gui.ui -o src/main/python/ayab/about_gui.py
+pyside6-uic src/main/python/ayab/firmware_flash_gui.ui -o src/main/python/ayab/firmware_flash_gui.py
+pyside6-uic src/main/python/ayab/main_gui.ui -o src/main/python/ayab/main_gui.py
+pyside6-uic src/main/python/ayab/menu_gui.ui -o src/main/python/ayab/menu_gui.py
+pyside6-uic src/main/python/ayab/mirrors_gui.ui -o src/main/python/ayab/mirrors_gui.py
+pyside6-uic src/main/python/ayab/prefs_gui.ui -o src/main/python/ayab/prefs_gui.py
+pyside6-uic src/main/python/ayab/engine/dock_gui.ui -o src/main/python/ayab/engine/dock_gui.py
+pyside6-uic src/main/python/ayab/engine/options_gui.ui -o src/main/python/ayab/engine/options_gui.py
+pyside6-uic src/main/python/ayab/engine/status_gui.ui -o src/main/python/ayab/engine/status_gui.py
 
-# generate PyQt5 resource filea
-pyrcc5 src/main/python/ayab/ayab_logo_rc.qrc -o src/main/python/ayab/ayab_logo_rc.py
-pyrcc5 src/main/python/ayab/engine/lowercase_e_rc.qrc -o src/main/python/ayab/engine/lowercase_e_rc.py
-pyrcc5 src/main/python/ayab/engine/lowercase_e_reversed_rc.qrc -o src/main/python/ayab/engine/lowercase_e_reversed_rc.py
+# generate PySide6 resource filea
+pyside6-rcc src/main/python/ayab/ayab_logo_rc.qrc -o src/main/python/ayab/ayab_logo_rc.py
+pyside6-rcc src/main/python/ayab/engine/lowercase_e_rc.qrc -o src/main/python/ayab/engine/lowercase_e_rc.py
+pyside6-rcc src/main/python/ayab/engine/lowercase_e_reversed_rc.qrc -o src/main/python/ayab/engine/lowercase_e_reversed_rc.py
 
 # generate translation files
 cd src/main/resources/base/ayab/translations/

--- a/src/build/settings/mac.json
+++ b/src/build/settings/mac.json
@@ -2,5 +2,6 @@
     "mac_bundle_identifier": "",
     "resources_to_filter": [
         "src/main/resources/mac-frozen/Contents/Info.plist"
-    ]
+    ],
+    "extra_pyinstaller_args": ["--target-arch","universal2"]
 }

--- a/src/main/python/ayab/about.py
+++ b/src/main/python/ayab/about.py
@@ -17,8 +17,8 @@
 #    Copyright 2014 Sebastian Oliva, Christian Obersteiner, Andreas Müller, Christian Gerbrandt
 #    https://github.com/AllYarnsAreBeautiful/ayab-desktop
 
-from PyQt5.QtWidgets import QFrame
-from PyQt5.QtCore import Qt, QCoreApplication
+from PySide6.QtWidgets import QFrame
+from PySide6.QtCore import Qt, QCoreApplication
 
 from .about_gui import Ui_AboutForm
 from . import utils

--- a/src/main/python/ayab/about_gui.ui
+++ b/src/main/python/ayab/about_gui.ui
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-	to create Python file use
-	`pyuic5 -‑from-imports ayab_about.ui -o ayab_about.py`
--->
 <ui version="4.0">
  <class>AboutForm</class>
  <widget class="QWidget" name="AboutForm">
@@ -74,8 +70,5 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="ayab.ayab_logo.qrc"/>
- </resources>
  <connections/>
 </ui>

--- a/src/main/python/ayab/audio.py
+++ b/src/main/python/ayab/audio.py
@@ -24,7 +24,7 @@ from os import path
 import simpleaudio as sa
 import wave
 
-from PyQt5.QtCore import QObject, QThread
+from PySide6.QtCore import QObject, QThread
 
 
 class AudioWorker(QObject):

--- a/src/main/python/ayab/ayab.py
+++ b/src/main/python/ayab/ayab.py
@@ -23,8 +23,8 @@ from fbs_runtime.application_context.PyQt5 import ApplicationContext
 import sys
 import logging
 
-from PyQt5.QtWidgets import QMainWindow, QApplication, QMessageBox
-from PyQt5.QtCore import Qt, QThread, QCoreApplication, QTimer
+from PySide6.QtWidgets import QMainWindow
+from PySide6.QtCore import QCoreApplication
 
 from .main_gui import Ui_MainWindow
 from .gui_fsm import gui_fsm

--- a/src/main/python/ayab/engine/communication_mock.py
+++ b/src/main/python/ayab/engine/communication_mock.py
@@ -24,8 +24,7 @@ import logging
 from time import sleep
 from collections import deque
 
-from PyQt5 import QtWidgets
-from PyQt5.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QMessageBox
 
 from .communication import Communication, Token
 
@@ -107,9 +106,9 @@ class CommunicationMock(Communication):
             if self.__step:
                 # pop up box waits for user input before moving on to next line
                 msg = QMessageBox()
-                msg.setIcon(QMessageBox.Information)
+                msg.setIcon(QMessageBox.Icon.Information)
                 msg.setText("Line number = " + str(self.__line_count))
-                msg.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
+                msg.setStandardButtons(QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel)
                 ret = None
                 ret = msg.exec_()
                 while ret == None:

--- a/src/main/python/ayab/engine/control.py
+++ b/src/main/python/ayab/engine/control.py
@@ -21,8 +21,6 @@
 import logging
 from bitarray import bitarray
 
-from PyQt5.QtCore import QCoreApplication
-
 from ..signal_sender import SignalSender
 from .communication import Communication, Token
 from .communication_mock import CommunicationMock

--- a/src/main/python/ayab/engine/engine.py
+++ b/src/main/python/ayab/engine/engine.py
@@ -44,7 +44,7 @@ class Engine(SignalSender, QDockWidget):
 
     Implemented as a subclass of `QDockWidget` and `SignalSender`.
     """
-    port_opener = pyqtSignal()
+    port_opener = Signal()
 
     def __init__(self, parent):
         # set up UI

--- a/src/main/python/ayab/engine/engine.py
+++ b/src/main/python/ayab/engine/engine.py
@@ -22,8 +22,8 @@ import logging
 from time import sleep
 from PIL import Image
 
-from PyQt5.QtCore import QTranslator, QCoreApplication, QLocale, QObjectCleanupHandler, pyqtSignal
-from PyQt5.QtWidgets import QComboBox, QDockWidget, QWidget
+from PySide6.QtCore import QCoreApplication, Signal
+from PySide6.QtWidgets import QDockWidget
 
 from .. import utils
 from ..signal_sender import SignalSender
@@ -62,7 +62,7 @@ class Engine(SignalSender, QDockWidget):
         self.control = Control(parent, self)
         self.__feedback = FeedbackHandler(parent)
         self.__logger = logging.getLogger(type(self).__name__)
-        self.setWindowTitle("Machine: " + Machine(self.control.prefs.value("machine")).name)
+        self.setWindowTitle("Machine: " + Machine(self.config.machine).name)
 
     def __del__(self):
         self.control.stop()

--- a/src/main/python/ayab/engine/engine_fsm.py
+++ b/src/main/python/ayab/engine/engine_fsm.py
@@ -20,9 +20,7 @@
 
 from enum import Enum, auto
 
-# from PyQt5.QtCore import QStateMachine, QState
-from PyQt5.QtCore import QCoreApplication
-from PyQt5.QtWidgets import QApplication
+from PySide6.QtCore import QCoreApplication
 
 from .communication import Communication, Token
 from .communication_mock import CommunicationMock

--- a/src/main/python/ayab/engine/hw_test_communication_mock.py
+++ b/src/main/python/ayab/engine/hw_test_communication_mock.py
@@ -19,7 +19,7 @@
 
 import re
 from time import sleep
-from PyQt5.QtCore import QObject, pyqtSignal
+from PySide6.QtCore import QObject
 
 from .communication import Token
 from .communication_mock import CommunicationMock

--- a/src/main/python/ayab/engine/mode.py
+++ b/src/main/python/ayab/engine/mode.py
@@ -21,7 +21,7 @@
 import logging
 from enum import Enum
 
-from PyQt5.QtCore import QCoreApplication
+from PySide6.QtCore import QCoreApplication
 
 from ayab.utils import odd, even
 

--- a/src/main/python/ayab/engine/options.py
+++ b/src/main/python/ayab/engine/options.py
@@ -21,8 +21,8 @@
 from enum import Enum
 
 from PySide6.QtCore import Qt, QCoreApplication
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtGui import QPixmap
+from PySide6.QtWidgets import QWidget
+from PySide6.QtGui import QPixmap
 
 from ayab.signal_sender import SignalSender
 from .options_gui import Ui_Options

--- a/src/main/python/ayab/engine/options.py
+++ b/src/main/python/ayab/engine/options.py
@@ -20,7 +20,7 @@
 
 from enum import Enum
 
-from PyQt5.QtCore import Qt, QCoreApplication, QSettings
+from PySide6.QtCore import Qt, QCoreApplication
 from PyQt5.QtWidgets import QWidget
 from PyQt5.QtGui import QPixmap
 

--- a/src/main/python/ayab/engine/options_gui.ui
+++ b/src/main/python/ayab/engine/options_gui.ui
@@ -244,7 +244,8 @@
     <item>
      <widget class="QLabel" name="auto_mirror_icon">
       <property name="pixmap">
-       <pixmap resource="lowercase_e_reversed_rc.qrc">:/garamond-lowercase-e-reversed.png</pixmap>
+      </property>
+      <property name="baseSize">
        <size>
         <width>32</width>
         <height>32</height>
@@ -262,8 +263,5 @@
    </layout>
   </widget>
  </widget>
- <resources>
-  <include location="ayab.engine.lowercase_e_reversed.qrc"/>
- </resources>
  <connections/>
 </ui>

--- a/src/main/python/ayab/engine/status.py
+++ b/src/main/python/ayab/engine/status.py
@@ -20,8 +20,8 @@
 from enum import Enum
 from bitarray import bitarray
 
-from PyQt5.QtCore import QCoreApplication
-from PyQt5.QtWidgets import QWidget
+from PySide6.QtCore import QCoreApplication
+from PySide6.QtWidgets import QWidget
 
 from .status_gui import Ui_StatusTab
 

--- a/src/main/python/ayab/firmware_flash.py
+++ b/src/main/python/ayab/firmware_flash.py
@@ -17,9 +17,8 @@
 #    Copyright 2014 Sebastian Oliva, Christian Obersteiner, Andreas Müller, Christian Gerbrandt
 #    https://github.com/AllYarnsAreBeautiful/ayab-desktop
 
-from PyQt5 import QtGui, QtWidgets
-from PyQt5.QtCore import QSettings, QCoreApplication
-from PyQt5.QtWidgets import QDialog, QListWidgetItem
+from PySide6.QtCore import QCoreApplication
+from PySide6.QtWidgets import QDialog, QListWidgetItem
 
 import serial
 import json

--- a/src/main/python/ayab/gui_fsm.py
+++ b/src/main/python/ayab/gui_fsm.py
@@ -20,8 +20,7 @@
 
 import logging
 
-from PyQt5.QtCore import QStateMachine, QState, QObject
-
+from PySide6.QtStateMachine import QStateMachine, QState
 
 class gui_fsm(object):
     """Finite State Machine for GUI thread.

--- a/src/main/python/ayab/hw_test.py
+++ b/src/main/python/ayab/hw_test.py
@@ -19,9 +19,9 @@
 
 from copy import copy
 import serial
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QPlainTextEdit, QButtonGroup, QPushButton, QGroupBox, QHBoxLayout, QCheckBox
-from PyQt5.QtGui import QFont
-from PyQt5.QtCore import QTimer
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QPlainTextEdit, QPushButton, QGroupBox, QHBoxLayout, QCheckBox
+from PySide6.QtGui import QFont
+from PySide6.QtCore import QTimer
 
 #from .cmd_buttons import CmdButtons
 from .engine.engine_fsm import State

--- a/src/main/python/ayab/image.py
+++ b/src/main/python/ayab/image.py
@@ -22,8 +22,8 @@ import logging
 from math import ceil
 
 from PIL import Image
-from PyQt5.QtCore import QCoreApplication
-from PyQt5.QtWidgets import QInputDialog, QDialog, QFileDialog
+from PySide6.QtCore import QCoreApplication
+from PySide6.QtWidgets import QInputDialog, QDialog, QFileDialog
 
 from .transforms import Transform, Mirrors
 from .signal_sender import SignalSender

--- a/src/main/python/ayab/knitprogress.py
+++ b/src/main/python/ayab/knitprogress.py
@@ -17,8 +17,8 @@
 #    Copyright 2014 Sebastian Oliva, Christian Obersteiner, Andreas Müller, Christian Gerbrandt
 #    https://github.com/AllYarnsAreBeautiful/ayab-desktop
 
-from PyQt5.QtCore import Qt, QCoreApplication, QRect, QSize
-from PyQt5.QtWidgets import QTableWidget, QTableWidgetItem, QLabel, QSizePolicy, QAbstractItemView, QWidget, QHBoxLayout, QHeaderView
+from PySide6.QtCore import QCoreApplication, QRect, QSize
+from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QLabel, QHeaderView
 from bitarray import bitarray
 
 from . import utils

--- a/src/main/python/ayab/language.py
+++ b/src/main/python/ayab/language.py
@@ -19,7 +19,7 @@
 
 from os import path
 from glob import glob
-from PyQt5.QtCore import QLocale
+from PySide6.QtCore import QLocale
 
 
 class Language(object):

--- a/src/main/python/ayab/machine.py
+++ b/src/main/python/ayab/machine.py
@@ -17,8 +17,6 @@
 #    Copyright 2013 Christian Obersteiner, Andreas Müller, Christian Gerbrandt
 #    https://github.com/AllYarnsAreBeautiful/ayab-desktop
 
-# from PyQt5.QtCore import QCoreApplication
-
 from enum import Enum
 
 

--- a/src/main/python/ayab/main_gui.ui
+++ b/src/main/python/ayab/main_gui.ui
@@ -139,7 +139,7 @@
         <item>
          <layout class="QVBoxLayout" name="widget_imgload">
           <item>
-           <layout class="QHBoxLayout" name="horizontal_layout">
+           <layout class="QHBoxLayout" name="horizontal_layout1">
             <item>
              <spacer name="horizontalSpacer">
               <property name="orientation">

--- a/src/main/python/ayab/menu.py
+++ b/src/main/python/ayab/menu.py
@@ -17,7 +17,7 @@
 #    Copyright 2014 Sebastian Oliva, Christian Obersteiner, Andreas Müller, Christian Gerbrandt
 #    https://github.com/AllYarnsAreBeautiful/ayab-desktop
 
-from PyQt5.QtWidgets import QMenuBar
+from PySide6.QtWidgets import QMenuBar
 
 from .menu_gui import Ui_MenuBar
 

--- a/src/main/python/ayab/preferences.py
+++ b/src/main/python/ayab/preferences.py
@@ -128,7 +128,7 @@ class Preferences(SignalSender):
 
     def open_dialog(self):
         machine_width = Machine(self.value("machine")).width
-        result = PrefsDialog(self.parent).exec_()
+        result = PrefsDialog(self.parent).exec()
         if machine_width != Machine(self.value("machine")).width:
             self.emit_image_resizer()
 
@@ -156,7 +156,7 @@ class PrefsDialog(QDialog):
 
         # connect dialog box buttons
         for widget in self.__widget.values():
-            widget.connect()
+            widget.connectChange()
         self.__ui.reset.clicked.connect(self.__reset_and_refresh)
         self.__ui.enter.clicked.connect(self.accept)
 
@@ -197,7 +197,7 @@ class PrefsBoolWidget(QCheckBox):
         self.var = var
         self.prefs = prefs
 
-    def connect(self):
+    def connectChange(self):
         self.toggled.connect(self.update_setting)
 
     def update_setting(self):
@@ -208,9 +208,9 @@ class PrefsBoolWidget(QCheckBox):
 
     def refresh(self):
         if self.prefs.value(self.var):
-            self.setCheckState(Qt.Checked)
+            self.setCheckState(Qt.CheckState.Checked)
         else:
-            self.setCheckState(Qt.Unchecked)
+            self.setCheckState(Qt.CheckState.Unchecked)
 
 
 class PrefsComboWidget(QComboBox):
@@ -226,7 +226,7 @@ class PrefsComboWidget(QComboBox):
         cls = self.prefs.variables[self.var]
         cls.add_items(self)
 
-    def connect(self):
+    def connectChange(self):
         self.currentIndexChanged.connect(self.update_setting)
 
     def update_setting(self):
@@ -247,7 +247,7 @@ class PrefsLangWidget(QComboBox):
         self.prefs = prefs
         self.prefs.languages.add_items(self)
 
-    def connect(self):
+    def connectChange(self):
         self.currentIndexChanged.connect(self.update_setting)
 
     def update_setting(self):

--- a/src/main/python/ayab/preferences.py
+++ b/src/main/python/ayab/preferences.py
@@ -25,8 +25,8 @@ The method of configuration may differ depending on the OS.
 
 import re
 
-from PyQt5.QtCore import Qt, QSettings, QCoreApplication
-from PyQt5.QtWidgets import QDialog, QFormLayout, QLabel, QCheckBox, QComboBox
+from PySide6.QtCore import Qt, QSettings, QCoreApplication
+from PySide6.QtWidgets import QDialog, QFormLayout, QLabel, QCheckBox, QComboBox
 
 from .prefs_gui import Ui_Prefs
 from .signal_sender import SignalSender

--- a/src/main/python/ayab/scene.py
+++ b/src/main/python/ayab/scene.py
@@ -21,9 +21,9 @@
 import logging
 from enum import Enum
 
-from PyQt5.QtCore import QRect
-from PyQt5.QtGui import QImage, QPixmap, QPen, QBrush, QColor
-from PyQt5.QtWidgets import QGraphicsScene, QGraphicsRectItem, QGraphicsView
+from PySide6.QtCore import QRect
+from PySide6.QtGui import QImage, QPixmap, QPen, QBrush, QColor
+from PySide6.QtWidgets import QGraphicsScene, QGraphicsRectItem, QGraphicsView
 
 from .image import AyabImage, Transform
 from .engine.options import Alignment

--- a/src/main/python/ayab/signal_receiver.py
+++ b/src/main/python/ayab/signal_receiver.py
@@ -18,7 +18,7 @@
 #    Copyright 2014 Sebastian Oliva, Christian Obersteiner, Andreas Müller, Christian Gerbrandt
 #    https://github.com/AllYarnsAreBeautiful/ayab-desktop
 
-from PyQt5.QtCore import QObject, pyqtSignal, Qt
+from PySide6.QtCore import QObject, Signal, Qt
 from .engine.status import Status
 from .engine.options import Alignment
 from .engine.engine_fsm import Operation
@@ -35,25 +35,25 @@ class SignalReceiver(QObject):
     """
     # signals are defined as class attributes which are
     # over-ridden by instance attributes with the same name
-    start_row_updater = pyqtSignal(int)
-    progress_bar_updater = pyqtSignal(int, int, int, 'QString')
-    knit_progress_updater = pyqtSignal(Status, int, int, bool)
-    notifier = pyqtSignal('QString', bool)
-    # statusbar_updater = pyqtSignal('QString', bool)
-    popup_displayer = pyqtSignal('QString', 'QString')
-    blocking_popup_displayer = pyqtSignal('QString', 'QString')
-    audio_player = pyqtSignal('QString')
-    needles_updater = pyqtSignal(int, int)
-    alignment_updater = pyqtSignal(Alignment)
-    image_resizer = pyqtSignal()
-    image_reverser = pyqtSignal()
-    got_image_flag = pyqtSignal()
-    new_image_flag = pyqtSignal()
-    bad_config_flag = pyqtSignal()
-    knitting_starter = pyqtSignal()
-    operation_finisher = pyqtSignal(Operation, bool)
-    hw_test_starter = pyqtSignal(Control)
-    hw_test_writer = pyqtSignal(str)
+    start_row_updater = Signal(int)
+    progress_bar_updater = Signal(int, int, int, 'QString')
+    knit_progress_updater = Signal(Status, int, int, bool)
+    notifier = Signal('QString', bool)
+    # statusbar_updater = Signal('QString', bool)
+    popup_displayer = Signal('QString', 'QString')
+    blocking_popup_displayer = Signal('QString', 'QString')
+    audio_player = Signal('QString')
+    needles_updater = Signal(int, int)
+    alignment_updater = Signal(Alignment)
+    image_resizer = Signal()
+    image_reverser = Signal()
+    got_image_flag = Signal()
+    new_image_flag = Signal()
+    bad_config_flag = Signal()
+    knitting_starter = Signal()
+    operation_finisher = Signal(Operation, bool)
+    hw_test_starter = Signal(Control)
+    hw_test_writer = Signal(str)
 
     def __init__(self):
         super().__init__()
@@ -61,7 +61,7 @@ class SignalReceiver(QObject):
     def signals(self):
         """Iterator over names of signals."""
         return filter(
-            lambda x: type(getattr(self, x)).__name__ == "pyqtBoundSignal",
+            lambda x: type(getattr(self, x)).__name__ == "SignalInstance",
             SignalReceiver.__dict__.keys())
 
     def activate_signals(self, parent):

--- a/src/main/python/ayab/signal_sender.py
+++ b/src/main/python/ayab/signal_sender.py
@@ -18,7 +18,7 @@
 #    Andreas Müller, Christian Gerbrandt
 #    https://github.com/AllYarnsAreBeautiful/ayab-desktop
 
-from PyQt5.QtCore import QCoreApplication
+from PySide6.QtCore import QCoreApplication
 
 
 class SignalSender(object):

--- a/src/main/python/ayab/statusbar.py
+++ b/src/main/python/ayab/statusbar.py
@@ -19,7 +19,7 @@
 """Notification methods using the status bar."""
 
 import logging
-from PyQt5.QtWidgets import QStatusBar
+from PySide6.QtWidgets import QStatusBar
 
 
 class StatusBar(QStatusBar):

--- a/src/main/python/ayab/thread.py
+++ b/src/main/python/ayab/thread.py
@@ -17,7 +17,7 @@
 #    Copyright 2014 Sebastian Oliva, Christian Obersteiner, Andreas Müller, Christian Gerbrandt
 #    https://github.com/AllYarnsAreBeautiful/ayab-desktop
 
-from PyQt5.QtCore import QThread
+from PySide6.QtCore import QThread
 
 
 class GenericThread(QThread):

--- a/src/main/python/ayab/transforms.py
+++ b/src/main/python/ayab/transforms.py
@@ -20,7 +20,7 @@
 import logging
 from PIL import Image, ImageOps
 
-from PyQt5.QtWidgets import QDialog
+from PySide6.QtWidgets import QDialog
 
 from .mirrors_gui import Ui_Mirrors
 

--- a/src/main/python/ayab/utils.py
+++ b/src/main/python/ayab/utils.py
@@ -24,7 +24,7 @@ import numpy as np
 import serial.tools.list_ports
 import requests
 
-from PyQt5.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QMessageBox
 
 
 def even(x):

--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -1,4 +1,4 @@
-from fbs_runtime.application_context.PyQt5 import \
+from fbs_runtime.application_context.PySide6 import \
     ApplicationContext, cached_property
 
 import sys
@@ -6,9 +6,8 @@ from os import path
 import logging
 from distutils.dir_util import copy_tree
 
-from PyQt5.QtCore import \
+from PySide6.QtCore import \
     Qt, QCoreApplication, QTranslator, QLocale, QSettings
-from PyQt5.QtWidgets import QApplication
 
 from ayab.ayab import GuiMain
 from ayab import utils
@@ -22,11 +21,6 @@ class AppContext(ApplicationContext):  # 1. Subclass ApplicationContext
         super().__init__(*args, **kwargs)
 
     def configure_application(self):
-        # Fix PyQt5 for HiDPI screens
-        if hasattr(Qt, 'AA_EnableHighDpiScaling'):
-            QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
-        if hasattr(Qt, 'AA_UseHighDpiPixmaps'):
-            QCoreApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
         # Remove Help Button
         if hasattr(Qt, 'AA_DisableWindowContextHelpButton'):
             QCoreApplication.setAttribute(
@@ -43,7 +37,7 @@ class AppContext(ApplicationContext):  # 1. Subclass ApplicationContext
             url = "https://github.com/" + self.REPO + "/releases/tag/" + tag
             utils.display_blocking_popup(
                "<p>A new version of the AYAB desktop software has been released! You can download version <strong>" + tag + "</strong> using this link:<br/><br/><a href='" + url + "'>" + url + "</a></p>")
-        return self.app.exec_()  # 3. End run() with this line
+        return self.app.exec()  # 3. End run() with this line
 
     def check_new_version(self, repo):
         try:


### PR DESCRIPTION
This should make Mac builds work.

This PR brings the following changes:
- Update our base Python dependency to 3.11, the latest stable release at the time of this PR.
- Update our Qt dependency from Qt5 to Qt6, migrating us from `PyQt5` to `PySide6`. (as PySide6 provides universal binaries and PyQt does not)
- Update our `Pillow` dependency to 10.0 (needed for Mac universal binary support)
- Lock our `numpy` & `requests` dependencies to specific versions (to ensure build consistency).
- Break out build and development dependencies into `requirements.build.txt` & `requirements.txt` (so as not to pollute the build instance with e.g. `pre-commit`)
- Update README.md to reflect actual build requirements on all supported platforms, as well as some adjustments to clean up the flow and reduce repetition.
- Update our Github Actions builder to use the new Apple m1 runner for mac builds- this greatly simplifies building universal binaries for mac.

Additionally, this change also required some hacking on fbs, which I've similarly upgraded from Qt5 to Qt6, covered in this PR: AllYarnsAreBeautiful/fbs#6

This is a remake of #572 