### PR TITLE
Update ayab_trans to run on windows

### DIFF
--- a/src/main/resources/base/ayab/translations/ayab_trans.pl
+++ b/src/main/resources/base/ayab/translations/ayab_trans.pl
@@ -15,6 +15,21 @@ use warnings;
 use List::Util qw(first);
 use File::Spec::Functions;
 
+#index, infile, outfile
+sub cut{
+open(my $infile, "<",$_[1]);
+open(my $outfile, ">",$_[2]);
+while (my $line = <$infile>) {
+	my @b = split(/\t/,$line);
+	print $outfile @b[$_[0]-1],"\n";
+}
+}
+
+#filenames
+sub rm{
+    unlink(@_)
+}
+
 my $master = "ayab-translation-master.tsv";
 open(FILE, "<", $master);
 chomp(my $line = <FILE>);
@@ -23,29 +38,29 @@ close(FILE);
 
 my $index = (first { $headers[$_] eq "Context" } 0 .. $#headers) + 1;
 my $filename = "ayab_trans_context.txt";
-system("cut -f$index $master > $filename");
+cut($index, $master, $filename);
 open(FILE, "<", $filename);
 chomp(my @context = <FILE>);
 close(FILE);
-system("rm $filename");
+rm($filename);
 
 $index += 1;
 $filename = "ayab_trans_base.txt";
-system("cut -f$index $master > $filename");
+cut($index, $master, $filename);
 open(FILE, "<", $filename);
 chomp(my @base = <FILE>);
 close(FILE);
-system("rm $filename");
+rm($filename);
 
 foreach my $column ($index .. $#headers){
         my $lang = $headers[$column-1];
         my $filename = "ayab_trans_$lang.txt";
-	system("cut -f$column $master > $filename");
+	cut($column, $master, $filename);
 	open(FILE, "<", $filename);
 	chomp(my @file = <FILE>);
 	close(FILE);
-	system("rm $filename");
-        $filename = "ayab_trans.$lang.ts";
+	rm($filename);
+    $filename = "ayab_trans.$lang.ts";
 	open(FILE, ">", $filename);
 	print FILE <<'HEADER';
 <?xml version="1.0" encoding="utf-8"?>
@@ -75,4 +90,4 @@ HEADER
 # run `lrelease *.ts` to create binary `.qm` files
 open(FILE, "<", $master);
 system("lrelease *.ts");
-system("rm -f *.ts");
+unlink glob "*.ts";


### PR DESCRIPTION
This gets rid of the system calls to `cut` and `rm` and uses perl functions instead, which should be theoretically faster on all platforms, and make it work at all on windows.
Addresses #650 