### PR TITLE
Make knitting match what you see

### DIFF
--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -4,7 +4,7 @@ PyInstaller==6.4.0
 Pillow==10
 pyserial==3.5
 sliplib==0.6.2
-bitarray-hardbyte==2.3.8
+bitarray==2.9.2
 simpleaudio==1.0.4
 wave==0.0.2
 numpy==1.26.4

--- a/src/main/python/main/ayab/engine/communication.py
+++ b/src/main/python/main/ayab/engine/communication.py
@@ -174,6 +174,8 @@ class Communication(object):
           color (int): The yarn color to be sent.
           flags (int): The flags sent to the controller.
           line_data (bytes): The bytearray to be sent to needles.
+              The leftmost needle is controlled by the least-significant bit of
+              the first byte.
         """
         if self.__ser is None:
             return

--- a/src/main/python/main/ayab/engine/control.py
+++ b/src/main/python/main/ayab/engine/control.py
@@ -265,7 +265,7 @@ class Control(SignalSender):
     def select_needles_API6(
         self, color: int, row_index: int, blank_line: bool
     ) -> bitarray:
-        bits = bitarray([False] * self.machine.width, endian="little")
+        bits = bitarray(self.machine.width, endian="little")
 
         # select needles flanking the pattern
         # if necessary to knit the background color

--- a/src/main/python/main/ayab/engine/engine.py
+++ b/src/main/python/main/ayab/engine/engine.py
@@ -123,7 +123,7 @@ class Engine(SignalSender, QDockWidget):
         self.__logger.debug(self.config.as_dict())
 
         # start to knit with the bottom first
-        image = image.transpose(Image.ROTATE_180)
+        image = image.transpose(Image.FLIP_TOP_BOTTOM)
 
         # TODO: detect if previous conf had the same
         # image to avoid re-generating.

--- a/src/main/python/main/ayab/engine/pattern.py
+++ b/src/main/python/main/ayab/engine/pattern.py
@@ -59,7 +59,7 @@ class Pattern(object):
             [0 for i in range(self.__num_colors)] for j in range(self.__pat_height)
         ]  # unused
         self.__pattern_expanded = [
-            bitarray([False] * self.__pat_width)
+            bitarray(self.__pat_width)
             for j in range(self.__num_colors * self.__pat_height)
         ]
 

--- a/src/main/python/main/ayab/knitprogress.py
+++ b/src/main/python/main/ayab/knitprogress.py
@@ -120,7 +120,6 @@ class KnitProgress(QTableWidget):
         columns.append(carriage.symbol + " " + direction.symbol)
 
         # graph line of stitches
-        status.bits.reverse()
         midline = len(status.bits) - midline
 
         table_text = (


### PR DESCRIPTION
The most important change happens in `engine.py`: we now only flip the image vertically, instead of rotating it 180 degrees when preparing the pattern.

In `KnitProgress` we remove the left-to-right reversal that was done to compensate for the unnecessary mirroring.

In addition, while researching `bitarray` I discovered that we were using a discontinued fork of the official `bitarray` package. As far as I can tell there are no undesirable effects of switching back to the `bitarray` package, and since it now guarantees that arrays are initialized with zeroes, a couple uses can be simplified.

Fixes #613. Also fixes #614 I think, since the "Knit side image" checkbox appears to work, only the output needed to be unflipped.

Edit: please disregard the AI attempt at summarizing the changes below, it is wrong on multiple counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the initialization of bitarrays to ensure compatibility and performance improvements.

- **Documentation**
  - Added detailed documentation to the `cnf_line_API6` function to clarify bit control for the leftmost needle.

- **Enhancements**
  - Improved image handling in the `knit_config` method by changing image transformation to a top-to-bottom flip.
  - Optimized bitarray initialization in multiple modules for better efficiency.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->