### PR TITLE
Fix segfault on exit due to `QTableWidget` item reuse

### DIFF
--- a/src/main/python/main/ayab/knitprogress.py
+++ b/src/main/python/main/ayab/knitprogress.py
@@ -49,11 +49,11 @@ class KnitProgress(QTableWidget):
             QHeaderView.ResizeMode.ResizeToContents
         )
         self.verticalHeader().setVisible(False)
-        self.blank = QTableWidgetItem()
-        self.blank.setSizeHint(QSize(0, 0))
         self.setColumnCount(6)
         for r in range(6):
-            self.setHorizontalHeaderItem(r, self.blank)
+            blank = QTableWidgetItem()
+            blank.setSizeHint(QSize(0, 0))
+            self.setHorizontalHeaderItem(r, blank)
         self.previousStatus: Optional[Status] = None
         self.scene = parent.scene
 


### PR DESCRIPTION
This fixes #640. I could reproduce it and as in the attached crash report, the crash happens during `QTableWidget` cleanup.

Using the same `QTableWidgetItem` multiple times seems to cause a multiple-delete upon destruction of the `QTableWidget`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the responsiveness of the knitting progress display by adjusting the way header items are created in the loop. This ensures more accurate updates and visual consistency in the progress table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->