### PR TITLE
Fix macOS build with new bitarray package

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -313,15 +313,23 @@ jobs:
         run: |
           brew install avrdude
           brew install qt
-          python -m pip install delocate
-          python -m pip download --only-binary=:all: --platform macosx_10_09_x86_64 numpy==1.26.4
-          python -m pip download --only-binary=:all: --platform macosx_11_0_arm64 numpy==1.26.4
           mkdir tmp-wheel/
+          python -m pip install delocate
+
+          # Find platform values on e.g. https://pypi.org/project/numpy/1.26.4/#files
+
+          python -m pip download --only-binary=:all: --platform macosx_10_09_x86_64 "$(grep numpy requirements.build.txt)"
+          python -m pip download --only-binary=:all: --platform macosx_11_0_arm64 "$(grep numpy requirements.build.txt)"
           delocate-fuse numpy*arm* numpy*x86* -w tmp-wheel/
-          python -m pip download --only-binary=:all: --platform macosx_10_10_x86_64 Pillow==10.0.0
-          python -m pip download --only-binary=:all: --platform macosx_11_0_arm64 Pillow==10.0.0
+
+          python -m pip download --only-binary=:all: --platform macosx_10_10_x86_64 "$(grep Pillow requirements.build.txt)"
+          python -m pip download --only-binary=:all: --platform macosx_11_0_arm64 "$(grep Pillow requirements.build.txt)"
           delocate-fuse Pillow*arm* Pillow*x86* -w tmp-wheel/
-          python -m pip install tmp-wheel/*.whl
+
+          python -m pip download --only-binary=:all: --platform=macosx_10_9_universal2 "$(grep bitarray requirements.build.txt)"
+
+          python -m pip install tmp-wheel/*.whl bitarray*.whl
+
           python -m pip install --no-binary charset_normalizer -r requirements.build.txt
       - name: Restore cached firmware
         id: firmware-cache


### PR DESCRIPTION
The `bitarray` package which was updated in #669 now has single-architecture macOS binary wheels available, which causes the app packaging to fail complaining that its native library is not a universal binary (see https://github.com/jonathanperret/ayab-desktop/actions/runs/9823270540/job/27121238943).

This PR applies a similar workaround as was employed to fix a similar problem for `numpy` and `Pillow`. In the `bitarray` case however, we don't have to merge two single-architecture wheels since fortunately a universal wheel is available, it's just not picked up by default by `pip install`.

I also improved the code that downloads the `numpy` and `Pillow` wheels a bit, so that it will track the version of these packages mentioned in `requirements.build.txt` instead of a hardcoded version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved build workflow to fetch platform-specific binaries for numpy and Pillow dependencies.
	- Added platform-specific download and installation steps for the bitarray dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->