### PR TITLE
Update lower knit display

### DIFF
--- a/src/main/python/main/ayab/ayab.py
+++ b/src/main/python/main/ayab/ayab.py
@@ -176,9 +176,7 @@ class GuiMain(QMainWindow):
         width, height = self.scene.ayabimage.image.size
         self.engine.config.update_needles()  # in case machine width changed
         self.engine.config.set_image_dimensions(width, height)
-        self.progbar.row = self.scene.row_progress + 1
-        self.progbar.total = height
-        self.progbar.refresh()
+        self.progbar.update(self.engine.status)
         self.notify(
             QCoreApplication.translate("Scene", "Image dimensions")
             + f": {width} x {height}",
@@ -191,8 +189,9 @@ class GuiMain(QMainWindow):
         self.scene.reverse()
 
     def update_start_row(self, start_row: int) -> None:
-        self.progbar.update(start_row)
         self.scene.row_progress = start_row
+        self.engine.status.current_row = start_row
+        self.progbar.update(self.engine.status)
 
     def notify(self, text: str, log: bool = True) -> None:
         """Update the notification field."""

--- a/src/main/python/main/ayab/engine/control.py
+++ b/src/main/python/main/ayab/engine/control.py
@@ -243,6 +243,7 @@ class Control(SignalSender):
             return True  # pattern finished
 
     def __update_status(self, line_number: int, color: int, bits: bitarray) -> None:
+        self.status.total_rows = self.pat_height
         self.status.current_row = self.pat_row + 1
         self.status.line_number = line_number
         if self.inf_repeat:

--- a/src/main/python/main/ayab/engine/engine.py
+++ b/src/main/python/main/ayab/engine/engine.py
@@ -142,9 +142,9 @@ class Engine(SignalSender, QDockWidget):
         self.pattern.alignment = self.config.alignment
 
         # update progress bar
-        self.emit_progress_bar_updater(
-            self.config.start_row + 1, self.pattern.pat_height, 0, ""
-        )
+        data = Status()
+        data.copy(self.status)
+        self.emit_progress_bar_updater(data)
 
         # switch to status tab
         # if self.config.continuous_reporting:
@@ -214,9 +214,7 @@ class Engine(SignalSender, QDockWidget):
             self.control.midline,
             self.config.auto_mirror,
         )
-        self.emit_progress_bar_updater(
-            data.current_row, self.pattern.pat_height, data.repeats, data.color_symbol
-        )
+        self.emit_progress_bar_updater(data)
 
     def cancel(self) -> None:
         self.__canceled = True

--- a/src/main/python/main/ayab/engine/status.py
+++ b/src/main/python/main/ayab/engine/status.py
@@ -165,6 +165,8 @@ class Status(object):
         self.carriage_type = status.carriage_type
         self.carriage_position = status.carriage_position
         self.carriage_direction = status.carriage_direction
+        self.total_rows = status.total_rows
+        self.mirror = status.mirror
 
     def parse_device_state_API6(self, state: Any, msg: bytes) -> None:
         if not (self.active):

--- a/src/main/python/main/ayab/knitprogress.py
+++ b/src/main/python/main/ayab/knitprogress.py
@@ -49,12 +49,6 @@ class KnitProgress(QTableWidget):
         self.verticalHeader().setSectionResizeMode(
             QHeaderView.ResizeMode.ResizeToContents
         )
-        # self.verticalHeader().setVisible(False)
-        self.setColumnCount(6)
-        for r in range(6):
-            blank = QTableWidgetItem()
-            blank.setSizeHint(QSize(0, 0))
-            self.setHorizontalHeaderItem(r, blank)
         self.previousStatus: Optional[Status] = None
         self.scene = parent.scene
 
@@ -62,7 +56,6 @@ class KnitProgress(QTableWidget):
         self.clearContents()
         self.clearSelection()
         self.setRowCount(0)
-        # self.horizontalHeader().setSectionHidden(5, False)
         self.setCurrentCell(-1, -1)
         self.color = True
 
@@ -164,9 +157,7 @@ class KnitProgress(QTableWidget):
                 header.setForeground(QBrush(QColor(f"#{self.green:06x}")))
                 header.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
                 self.setHorizontalHeaderItem(i,header)
-                # self.horizontalHeaderItem(i).setText((i)-(midline+info_columns))
         n_cols = len(columns)
-        print(n_cols)
         if n_cols < 4:
             self.hideColumn(5)
         self.resizeColumnsToContents()
@@ -190,5 +181,4 @@ class KnitProgress(QTableWidget):
         else:
             if bg_color is not None:
                 stitch.setBackground(QBrush(QColor(f"#{bg_color:06x}")))
-            # text += "dotted;"
         return stitch

--- a/src/main/python/main/ayab/knitprogress.py
+++ b/src/main/python/main/ayab/knitprogress.py
@@ -89,39 +89,13 @@ class KnitProgress(QTableWidget):
 
         if status.current_row < 0:
             return
-        # else
-        tr_ = QCoreApplication.translate
-        row, swipe = divmod(status.line_number, row_multiplier)
 
         columns: List[QTableWidgetItem] = []
-        info_text = ""
-        info_header = QTableWidgetItem()
-        # row "Row [1]"
-        info_text= (tr_("KnitProgress", "Row") + " " + str(status.current_row))
-
-        # pass, see Mode object. "Pass [1,2,3]"
-        if row_multiplier == 1:
-            info_text= info_text+(" "+tr_("KnitProgress", "Pass") + " " + str(swipe + 1))
-
-        # color "Color [A,B,C,D]" 
         if status.color_symbol == "":
             self.color = False
         else:
             self.color = True
-            info_text = info_text + " " + tr_("KnitProgress", "Color") + " " + status.color_symbol
-            bgColor = QColor(f"#{status.color:06x}")
-            # Ensure text is readable
-            if bgColor.lightness() > 128:
-                bgColor.setHsl(bgColor.hslHue(),bgColor.hslSaturation(),128)
-            info_header.setForeground(QBrush(bgColor))
-
-        # Carriage & Direction "[K,L,G] [<-,->]"
-        carriage = status.carriage_type
-        direction = status.carriage_direction
-        info_text= info_text +(" "+carriage.symbol + " " + direction.symbol)
-
-        print(info_text)
-        info_header.setText(info_text)
+        info_header = self.format_row_header_text(status, row_multiplier)
 
         # graph line of stitches
         midline = len(status.bits) - midline
@@ -167,9 +141,33 @@ class KnitProgress(QTableWidget):
         # update bar in Scene
         self.scene.row_progress = status.current_row
 
-    def __item(self, text: str) -> QTableWidgetItem:
-        item = QTableWidgetItem(text)
-        return item
+    def format_row_header_text(self, status: Status, row_multiplier: int) -> QTableWidgetItem:
+        tr_ = QCoreApplication.translate
+        info_header = QTableWidgetItem()
+        info_text = ""
+        row, swipe = divmod(status.line_number, row_multiplier)
+        # row "Row [1]"
+        info_text= (tr_("KnitProgress", "Row") + " " + str(status.current_row))
+
+        # pass, see Mode object. "Pass [1,2,3]"
+        if row_multiplier == 1:
+            info_text= info_text+(" "+tr_("KnitProgress", "Pass") + " " + str(swipe + 1))
+
+        # color "Color [A,B,C,D]" 
+        if self.color is True:
+            info_text = info_text + " " + tr_("KnitProgress", "Color") + " " + status.color_symbol
+            background_color = QColor(f"#{status.color:06x}")
+            # Ensure text is readable
+            if background_color.lightness() > 128:
+                background_color.setHsl(background_color.hslHue(),background_color.hslSaturation(),128)
+            info_header.setForeground(QBrush(background_color))
+
+        # Carriage & Direction "[K,L,G] [<-,->]"
+        carriage = status.carriage_type
+        direction = status.carriage_direction
+        info_text= info_text +(" "+carriage.symbol + " " + direction.symbol)
+        info_header.setText(info_text)
+        return info_header
 
     def __stitch(self, color: int, bit: bool, alt_color: Optional[int] = None, bg_color: Optional[int] = None) -> QTableWidgetItem:
         stitch = QTableWidgetItem()

--- a/src/main/python/main/ayab/knitprogress.py
+++ b/src/main/python/main/ayab/knitprogress.py
@@ -172,8 +172,8 @@ class KnitProgress(QTableWidget):
     def __stitch(self, color: int, bit: bool, alt_color: Optional[int] = None, bg_color: Optional[int] = None) -> QTableWidgetItem:
         stitch = QTableWidgetItem()
         if bit:
-            bgColor = QColor(f"#{color:06x}")
-            stitch.setBackground(bgColor)
+            background_color = QColor(f"#{color:06x}")
+            stitch.setBackground(background_color)
         elif alt_color is not None:
             stitch.setBackground(QBrush(QColor(f"#{alt_color:06x}")))
         else:

--- a/src/main/python/main/ayab/knitprogress.py
+++ b/src/main/python/main/ayab/knitprogress.py
@@ -123,7 +123,7 @@ class KnitProgress(QTableWidget):
 
         for c in range(0, midline):
             columns.append(self.__stitch(
-                QColor(f"#{status.color:06x}"), cast(bool, status.bits[c]), status.alt_color, self.__alternate_bg_colors(midline-c, self.orange)
+                status.color, cast(bool, status.bits[c]), status.alt_color, self.__alternate_bg_colors(midline-c, self.orange)
             ))
 
         # if we are only working on the right side, midline is negative.
@@ -132,7 +132,7 @@ class KnitProgress(QTableWidget):
             green_start = 0
         for c in range(green_start, len(status.bits)):
             columns.append(self.__stitch(
-                QColor(f"#{status.color:06x}"), cast(bool, status.bits[c]), status.alt_color, self.__alternate_bg_colors(c-green_start, self.green)
+                status.color, cast(bool, status.bits[c]), status.alt_color, self.__alternate_bg_colors(c-green_start, self.green)
             ))
 
         return midline
@@ -207,7 +207,7 @@ class KnitProgress(QTableWidget):
             background_color.setHsl(floor(background_color.hslHue()*.85), floor(background_color.hslSaturation()*.85), background_color.lightness())
         return background_color
 
-    def __stitch(self, color: QColor, bit: bool, alt_color: Optional[int] = None, bg_color: Optional[QColor] = None) -> QTableWidgetItem:
+    def __stitch(self, color: int, bit: bool, alt_color: Optional[int] = None, bg_color: Optional[QColor] = None) -> QTableWidgetItem:
         stitch = QTableWidgetItem()
         if bit:
             background_color = QColor(f"#{color:06x}")

--- a/src/main/python/main/ayab/knitprogress.py
+++ b/src/main/python/main/ayab/knitprogress.py
@@ -19,8 +19,8 @@
 #    https://github.com/AllYarnsAreBeautiful/ayab-desktop
 
 from __future__ import annotations
-from PySide6.QtCore import QCoreApplication, QRect, QSize, Qt
-from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QLabel, QHeaderView
+from PySide6.QtCore import QCoreApplication, QRect, Qt
+from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QHeaderView
 from PySide6.QtGui import QBrush, QColor
 from typing import TYPE_CHECKING, Optional, cast, List
 

--- a/src/main/python/main/ayab/progressbar.py
+++ b/src/main/python/main/ayab/progressbar.py
@@ -20,10 +20,11 @@
 
 from __future__ import annotations
 from typing import TYPE_CHECKING
+from PySide6.QtGui import QColor
 
 if TYPE_CHECKING:
     from .ayab import GuiMain
-    from .engine.status import ColorSymbolType
+    from .engine.status import Status
 
 
 class ProgressBar(object):
@@ -40,23 +41,22 @@ class ProgressBar(object):
         self.total = -1
         self.repeats = -1
         self.color = ""
+        self.backgroundColor = 0xFFFFFF
         self.__row_label.setText("")
         self.__color_label.setText("")
         self.__status_label.setText("")
 
     def update(
         self,
-        row: int,
-        total: int = 0,
-        repeats: int = 0,
-        color_symbol: ColorSymbolType = "",
+        status: Status
     ) -> bool:
-        if row < 0:
+        if status.current_row < 0:
             return False
-        self.row = row
-        self.total = total
-        self.repeats = repeats
-        self.color = color_symbol
+        self.row = status.current_row
+        self.total = status.total_rows
+        self.repeats = status.repeats
+        self.color = status.color_symbol
+        self.backgroundColor = status.color
         self.refresh()
         return True
 
@@ -69,6 +69,12 @@ class ProgressBar(object):
             color_text = ""
         else:
             color_text = "Color " + self.color
+            bgColor = QColor.fromRgb(self.backgroundColor)
+            if bgColor.lightness() < 128:
+                fgColor = 0xffffff
+            else: fgColor = 0x000000
+            self.__color_label.setStyleSheet("QLabel {background-color: "+f"#{self.backgroundColor:06x}"+f";color:#{fgColor:06x}"+";}")
+
         self.__color_label.setText(color_text)
 
         # Update labels

--- a/src/main/python/main/ayab/progressbar.py
+++ b/src/main/python/main/ayab/progressbar.py
@@ -41,7 +41,7 @@ class ProgressBar(object):
         self.total = -1
         self.repeats = -1
         self.color = ""
-        self.backgroundColor = 0xFFFFFF
+        self.background_color = 0xFFFFFF
         self.__row_label.setText("")
         self.__color_label.setText("")
         self.__status_label.setText("")

--- a/src/main/python/main/ayab/progressbar.py
+++ b/src/main/python/main/ayab/progressbar.py
@@ -56,7 +56,7 @@ class ProgressBar(object):
         self.total = status.total_rows
         self.repeats = status.repeats
         self.color = status.color_symbol
-        self.backgroundColor = status.color
+        self.background_color = status.color
         self.refresh()
         return True
 
@@ -69,11 +69,11 @@ class ProgressBar(object):
             color_text = ""
         else:
             color_text = "Color " + self.color
-            bgColor = QColor.fromRgb(self.backgroundColor)
-            if bgColor.lightness() < 128:
-                fgColor = 0xffffff
-            else: fgColor = 0x000000
-            self.__color_label.setStyleSheet("QLabel {background-color: "+f"#{self.backgroundColor:06x}"+f";color:#{fgColor:06x}"+";}")
+            bg_color = QColor.fromRgb(self.background_color)
+            if bg_color.lightness() < 128:
+                fg_color = 0xffffff
+            else: fg_color = 0x000000
+            self.__color_label.setStyleSheet("QLabel {background-color: "+f"#{self.background_color:06x}"+f";color:#{fg_color:06x}"+";}")
 
         self.__color_label.setText(color_text)
 

--- a/src/main/python/main/ayab/signal_receiver.py
+++ b/src/main/python/main/ayab/signal_receiver.py
@@ -43,7 +43,7 @@ class SignalReceiver(QObject):
     # signals are defined as class attributes which are
     # over-ridden by instance attributes with the same name
     start_row_updater = Signal(int)
-    progress_bar_updater = Signal(int, int, int, str)
+    progress_bar_updater = Signal(Status)
     knit_progress_updater = Signal(Status, int, int, bool)
     notifier = Signal(str, bool)
     # statusbar_updater = Signal('QString', bool)

--- a/src/main/python/main/ayab/signal_sender.py
+++ b/src/main/python/main/ayab/signal_sender.py
@@ -50,10 +50,10 @@ class SignalSender(object):
         self.__signal_receiver.start_row_updater.emit(start_row)
 
     def emit_progress_bar_updater(
-        self, row: int, total: int, repeats: int, color_symbol: ColorSymbolType
+        self, status: Status
     ) -> None:
         self.__signal_receiver.progress_bar_updater.emit(
-            row, total, repeats, color_symbol
+            status
         )
 
     def emit_knit_progress_updater(


### PR DESCRIPTION
Update the lower knit progress display: 
- Add sticky headers on the top and left side
- Fix horizontal scrolling. 
- In Multicolor mode, colors the background of the knit progress view to show needles, alternating every 10 stitches.
- Adds color indication for current pass to the knit progress headers & the lower label.
- Adds a separator to delineate the row yet to-be-set.
- Adds a density preference, allowing for user-set stitch widths on the lower display.

Density 20:
![Screenshot 2024-07-14 232134](https://github.com/user-attachments/assets/911244c2-45f8-4acf-815e-352469f09a17)

Density 5:
![Screenshot 2024-07-14 231850](https://github.com/user-attachments/assets/5b1b2b80-606d-41f3-b461-35853584712b)

This addresses #668 #646 #615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced progress bar update functionality using a `Status` object for more efficient data handling.

- **Bug Fixes**
  - Fixed inconsistencies in the status update mechanism.

- **UI Improvements**
  - Updated UI elements in the knitting progress display, including table layout and color handling.

- **Preferences**
  - Introduced a new integer preference for `lower_display_stitch_width`.
  - Added new widget class for managing integer preferences.

- **Code Refactor**
  - Streamlined multiple methods to use `Status` objects instead of passing individual attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->