### PR TITLE
Remove requirement for separate Qt installation

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -104,8 +104,9 @@ jobs:
           (steps.e-cache.outputs.cache-hit    != 'true') ||
           (steps.qm-cache.outputs.cache-hit   != 'true') }}
         run: |
-          sudo apt install -y qt6-base-dev qt6-tools-dev-tools qt6-l10n-tools
-          PATH=/usr/lib/qt6/bin:$PATH bash setup-environment.ps1
+          # Install qt6 packages to bring in system dependencies only
+          sudo apt install -y qt6-base-dev qt6-tools-dev-tools
+          bash setup-environment.ps1
       - name: Cache gui files (1)
         if: ${{ (steps.gui1-cache.outputs.cache-hit != 'true') }}
         uses: actions/cache/save@v3
@@ -312,7 +313,6 @@ jobs:
         shell: zsh {0}
         run: |
           brew install avrdude
-          brew install qt
           mkdir tmp-wheel/
           python -m pip install delocate
 

--- a/README.md
+++ b/README.md
@@ -19,19 +19,18 @@ After cloning the repo and installing the development dependencies, you should r
         Linux
     </summary>
 
-For flashing the firmware, avrdude has to be available on your system.  
-To be able to work on GUI elements and translation files, you will also need Qt Dev & Localization Tools.
+For flashing the firmware, avrdude has to be available on your system.
+To build or run the application, you will also need the system libraries required by Qt 6; installing the Qt 6 development tools is a concise (if heavy-handed) way of bringing in these dependencies.
+
 #### Debian/Ubuntu
 ```bash
     sudo apt install python3.11 python3.11-dev python3.11-venv
-    sudo apt install libasound2-dev avrdude qt6-tools-dev-tools build-essential qt6-l10n-tools
-    export PATH=/usr/lib/qt6/bin:$PATH
+    sudo apt install libasound2-dev avrdude qt6-tools-dev-tools build-essential
 ```
 #### openSUSE
 ```bash
     sudo zypper install python311 python311-pip python311-virtualenv python311-devel
-    sudo zypper install libasound2 alsa-devel avrdude qt6-tools qt6-tools-linguist
-    export PATH=/usr/lib/qt6/bin:$PATH 
+    sudo zypper install libasound2 alsa-devel avrdude qt6-tools-dev-tools build-essential
 ```
 #### All Distributions
 
@@ -70,9 +69,6 @@ Activate the virtual environment. The command prompt should now display
 ```
 (You may skip the virtual environment setup below.)
 
-To be able to work on GUI elements and translation files, the Qt Dev tools are needed.  
-Navigate to [https://www.qt.io/download-open-source](https://www.qt.io/download-open-source) in a web browser and follow the installation
-instructions. From the available options, select "Custom install" and then "Qt 6.6.3".
 You will also need to download and install Perl from [https://www.perl.org/get.html](https://www.perl.org/get.html).
 </details>
 
@@ -88,10 +84,6 @@ You can install Git using Homebrew:
 You will also need the Xcode command line tools:
 ```bash
     xcode-select --install
-```
-To be able to work on GUI elements and translation files, the Qt Dev tools are needed also:
-```bash
-    brew install qt
 ```
 Install python from [the official universal2 installer](https://www.python.org/ftp/python/3.11.8/python-3.11.8-macos11.pkg). (Conda does not produce universal binaries)  
 
@@ -127,7 +119,6 @@ Next, convert the PySide6 `.ui` files and generate the translation files:
 ```bash
     bash ./setup-environment.ps1
 ```
-If you get errors about missing `lrelease`, you can skip this (if you do not need the translation files). To do so, comment out lines [23:26] of `setup-environment.ps1`.
 
 Finally, you can start AYAB with
 ```bash

--- a/src/main/resources/base/ayab/translations/ayab_trans.pl
+++ b/src/main/resources/base/ayab/translations/ayab_trans.pl
@@ -87,7 +87,7 @@ HEADER
 }
 
 # now that the `.ts` files have been generated
-# run `lrelease *.ts` to create binary `.qm` files
+# run `pyside6-lrelease *.ts` to create binary `.qm` files
 open(FILE, "<", $master);
-system("lrelease *.ts");
+system("pyside6-lrelease *.ts");
 unlink glob "*.ts";


### PR DESCRIPTION
The only reason to require a standalone Qt installation was the `lrelease` tool used to convert the translation files.

It turns out PySide6, which we install through `pip`, already includes this tool under the name `pyside6-lrelease`.

This PR changes the call from `lrelease` to `pyside6-lrelease`, and removes the installation of Qt from the GitHub Actions workflow and from the development setup instructions.

Except on Linux, where the Qt libraries which are bundled in PySide6 have themselves dependencies on system libraries such as `libgl1` and a dozen others. In that case it seemed simpler to keep installing a system Qt 6 package to pull these system dependencies in, even though none of the Qt components installed system-wide will be used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgraded Python environment setup to the latest version, enhancing compatibility and performance.
  - Streamlined installation process for Qt6 system dependencies for better efficiency.

- **Documentation**
  - Improved clarity and conciseness of the installation instructions in the README, focusing on essential steps for users.

- **Chores**
  - Updated command for generating binary files to ensure compatibility with newer versions of the PySide6 framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->