### PR TITLE
Remove audio player thread to fix crash on exit

### DIFF
--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -6,7 +6,6 @@ pyserial==3.5
 sliplib==0.6.2
 bitarray==2.9.2
 simpleaudio==1.0.4
-wave==0.0.2
 numpy==1.26.4
 charset-normalizer<3.0.0
 requests==2.31.0

--- a/src/main/python/main/ayab/signal_receiver.py
+++ b/src/main/python/main/ayab/signal_receiver.py
@@ -20,7 +20,7 @@
 #    https://github.com/AllYarnsAreBeautiful/ayab-desktop
 
 from __future__ import annotations
-from PySide6.QtCore import QObject, Signal, Qt
+from PySide6.QtCore import QObject, Signal
 from .engine.status import Status
 from .engine.options import Alignment
 from .engine.engine_fsm import Operation
@@ -73,9 +73,7 @@ class SignalReceiver(QObject):
         # self.statusbar_updater.connect(parent.statusbar.update)
         self.blocking_popup_displayer.connect(display_blocking_popup)
         self.popup_displayer.connect(display_blocking_popup)
-        self.audio_player.connect(
-            parent.audio.play, type=Qt.ConnectionType.BlockingQueuedConnection
-        )
+        self.audio_player.connect(parent.audio.play)
         self.needles_updater.connect(parent.scene.update_needles)
         self.alignment_updater.connect(parent.scene.update_alignment)
         self.image_resizer.connect(parent.set_image_dimensions)


### PR DESCRIPTION
## ⚡ Summary

This PR fixes issue #680 by removing the audio player thread which is the cause of the crash on exit, due to not being exited properly before app termination.

## ℹ️ Details

The current code spawns a dedicated thread (introduced in #382) to handle playing sound effects.

This is unnecessary as the `simpleaudio` API already is non-blocking, i.e. calling `wave_obj.play()` returns immediately while the sound plays in the background (see https://simpleaudio.readthedocs.io/en/latest/capabilities.html#asynchronous-interface). At the worst, loading the sound file, which is synchronous, could block the calling thread for a few milliseconds but that happens only once and is unlikely to be an issue.

The `AudioWorker.play` method does have a `blocking` argument that is supposed to support blocking the caller until the sound has finished playing, but this is never used in the current codebase.

But more conclusively, it turns out that due to an oversight, practically no code currently executes on the audio player thread. The `AudioWorker` object is assigned to a new thread, but because the `AudioPlayer.play` method calls `__worker.play` without going through a signal:
https://github.com/AllYarnsAreBeautiful/ayab-desktop/blob/bc96d5c3e3f955fa75551ec44c82e966e0981112/src/main/python/main/ayab/audio.py#L91-L92

…the `AudioWorker.play` method actually executes on the thread that called `AudioPlayer.play`. In practice this is the UI thread, because `audio.play` is called through a signal on `SignalReceiver`, which lives on that thread. Thus, the time-sensitive `engine` thread is already isolated from any slowness in reading or playing audio.

This commit reduces the `AudioPlayer` class to a plain Python object whose only responsibilities are to load and play the application's sound effects. It also simplifies the file loading logic by removing the direct call to the `wave` library in favor of the `from_wave_file` helper method offered by `simpleaudio`, which in practice uses the exact same call to the `wave` library.

A notable benefit of removing this thread is that the application no longer crashes with an `abort` call upon exit (issue #680), caused by improper termination of the audio thread.

## 🔬 How to test

- Knit a pattern from start to finish; observe that the _start_, _new line_ and _end_ sound effects are still played correctly. Note that (at least for me) when knitting in "Simulation" mode, the per-line sound effect is not heard; this is not a regression introduced by this PR since it already occured before and needs to be investigated separately.
- Follow the instructions in #680 to ascertain that a crash no longer happens on exit.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified audio playback functionality for a more efficient user experience.
  
- **Bug Fixes**
	- Removed unnecessary complexity in audio handling, which may improve responsiveness.

- **Refactor**
	- Streamlined the `AudioPlayer` class to enhance performance and maintainability by removing threading logic.
	- Updated signal connections to improve the handling of audio playback. 

- **Chores**
	- Removed unused dependencies from the project to minimize bloat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->