### PR TITLE
Upgrade PySide6 to 6.6.2 to fix macOS crashing bug (#682)

### DIFF
--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -1,5 +1,5 @@
 fbs @ git+https://github.com/AllYarnsAreBeautiful/fbs@1.2.1-pyqt6
-PySide6==6.6.1
+PySide6==6.6.2
 PyInstaller==6.4.0
 Pillow==10
 pyserial==3.5


### PR DESCRIPTION
This fixes #682 by upgrading to a Qt version that is not affected by the bug, as described in https://bugreports.qt.io/browse/QTBUG-120469

To minimize regression risks, I bumped the release of PySide6 just enough to contain the fix for the bug. As it turns out, it was fixed in the patch version just above the one we were using.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `PySide6` dependency to version `6.6.2`, potentially improving performance and stability of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->