### PR TITLE
Remove attempt to set flag that no longer exists in Qt 6

### DIFF
--- a/src/main/python/main/main.py
+++ b/src/main/python/main/main.py
@@ -6,7 +6,7 @@ from os import path
 import logging
 from distutils.dir_util import copy_tree
 
-from PySide6.QtCore import Qt, QCoreApplication, QTranslator, QLocale, QSettings
+from PySide6.QtCore import QCoreApplication, QTranslator, QLocale, QSettings
 
 from typing import TYPE_CHECKING, cast
 
@@ -28,15 +28,6 @@ else:
 
 class AppContext(ApplicationContext):  # type: ignore # 1. Subclass ApplicationContext
     REPO = "AllYarnsAreBeautiful/ayab-desktop"
-
-    def __init__(self) -> None:
-        self.configure_application()
-        super().__init__()
-
-    def configure_application(self) -> None:
-        # Remove Help Button
-        if hasattr(Qt, "AA_DisableWindowContextHelpButton"):
-            QCoreApplication.setAttribute(Qt.AA_DisableWindowContextHelpButton, True)
 
     def run(self) -> int:  # 2. Implement run()
         self.make_user_directory()


### PR DESCRIPTION
This is a really harmless thing, it just popped up as a warning in VS Code and I thought it was a neat opportunity to remove a few lines of code.

The `AA_DisableWindowContextHelpButton` application attribute was used to disable the context help button (`?` icon) from dialogs on Windows.

This attribute no longer exists in Qt 6, and [as documented in the Qt 5 docs](https://doc.qt.io/qtforpython-5/PySide2/QtCore/Qt.html#:~:text=Qt.AA_DisableWindowContextHelpButton) it is no longer necessary in Qt 6 since the default behavior is now to hide the button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined application initialization process, potentially improving startup behavior.
  
- **Bug Fixes**
	- Removed obsolete configuration steps that may have caused inconsistencies in application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->