### PR TITLE
Fix "knit side image" icon being cropped

### DIFF
--- a/src/main/python/main/ayab/engine/options_gui.ui
+++ b/src/main/python/main/ayab/engine/options_gui.ui
@@ -245,10 +245,10 @@
      <widget class="QLabel" name="auto_mirror_icon">
       <property name="pixmap">
       </property>
-      <property name="baseSize">
+      <property name="fixedSize">
        <size>
-        <width>32</width>
-        <height>32</height>
+        <width>59</width>
+        <height>64</height>
        </size>
       </property>
      </widget>


### PR DESCRIPTION
Fixes #685.

<img width="742" alt="ayab-windows-e-fixed" src="https://github.com/user-attachments/assets/98dcbdba-1921-47b9-805d-2a8e0739273a">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the visibility of the auto mirror icon in the user interface by increasing its dimensions and changing its size properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->