### PR TITLE
Use native menubar on macOS, not elsewhere (i.e. Linux)

### DIFF
--- a/src/main/python/main/ayab/menu.py
+++ b/src/main/python/main/ayab/menu.py
@@ -19,6 +19,7 @@
 #    https://github.com/AllYarnsAreBeautiful/ayab-desktop
 
 from __future__ import annotations
+from PySide6.QtCore import QOperatingSystemVersion
 from PySide6.QtWidgets import QMenuBar
 
 from .menu_gui import Ui_MenuBar
@@ -38,6 +39,11 @@ class Menu(QMenuBar):
 
     def __init__(self, parent: GuiMain):
         super().__init__(parent)
+
+        # Use native menubar on macOS, not elsewhere (i.e. Linux)
+        if QOperatingSystemVersion.currentType() != QOperatingSystemVersion.OSType.MacOS:
+            self.setNativeMenuBar(False)
+
         self.ui = Ui_MenuBar()
         self.ui.setupUi(self)
         self.setup()

--- a/src/main/python/main/ayab/menu_gui.ui
+++ b/src/main/python/main/ayab/menu_gui.ui
@@ -65,6 +65,9 @@
    <property name="shortcut">
     <string notr="true">Ctrl+Q</string>
    </property>
+   <property name="menuRole">
+    <enum>QAction::QuitRole</enum>
+   </property>
   </action>
   <action name="action_load_AYAB_firmware">
    <property name="text">
@@ -95,6 +98,9 @@
   <action name="action_about">
    <property name="text">
     <string>Help – About</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::AboutRole</enum>
    </property>
   </action>
   <action name="action_help">
@@ -188,6 +194,9 @@
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+P</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::PreferencesRole</enum>
    </property>
   </action>
  </widget>

--- a/src/main/python/main/ayab/menu_gui.ui
+++ b/src/main/python/main/ayab/menu_gui.ui
@@ -2,9 +2,6 @@
 <ui version="4.0">
  <class>MenuBar</class>
  <widget class="QMenuBar" name="menubar">
-  <property name="nativeMenuBar">
-   <bool>False</bool>
-  </property>
   <widget class="QMenu" name="menu_file">
    <property name="title">
     <string>File</string>


### PR DESCRIPTION
Fixes #694 .

This PR makes AYAB only disable the native menu bar when an OS other than macOS is detected. Or rather, it un-disables it if macOS is detected. Oh well, you know what I mean 😅.

In addition, Qt's [menu roles](https://doc.qt.io/qt-6/qmenubar.html#qmenubar-as-a-global-menu-bar) are leveraged to annotate the relevant actions (`About`, `Preferences`, `Quit`) so that they are automatically migrated to their [standardized](https://developer.apple.com/design/human-interface-guidelines/the-menu-bar#App-menu) locations in the native menu. Of course, the migrated menu items function as expected.

Here is the result:

https://github.com/user-attachments/assets/9a81af0d-01dc-4cd3-8ac4-2561b55bc1f7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced cross-platform compatibility by adjusting menu bar behavior based on the operating system.
	- Improved UI clarity with new action roles for menu items, enhancing user experience.

- **Bug Fixes**
	- Removed the native menu bar for non-macOS systems to ensure consistent menu appearance across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->