### PR TITLE
Upgrade GitHub actions to current supported versions

### DIFF
--- a/.github/actions/init-environment/action.yml
+++ b/.github/actions/init-environment/action.yml
@@ -34,7 +34,7 @@ runs:
         sed -i -e s/PACKAGE_VERSION/$version_without_suffix/ src/build/settings/base.json
     - name: Set up Python ${{ matrix.python-version }}
       id: py
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: "pip"

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -27,7 +27,7 @@ jobs:
         python-version: [3.11]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: ./.github/actions/init-environment
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install dependencies for doxygen
@@ -160,7 +160,7 @@ jobs:
           mkdir -p docs/html
           touch docs/html/.nojekyll
       - name: Deploy to pages
-        uses: DenverCoder1/doxygen-github-pages-action@v1.3.0
+        uses: DenverCoder1/doxygen-github-pages-action@v1.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages
@@ -176,7 +176,7 @@ jobs:
         python-version: [3.11]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: ./.github/actions/init-environment
@@ -290,7 +290,7 @@ jobs:
           artifacts: target/AYAB-${{ steps.vars.outputs.tag }}.exe
           artifactContentType: application/exe
           replacesArtifacts: true
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: AYAB-${{ steps.vars.outputs.tag }}.exe
           path: target/AYAB-${{ steps.vars.outputs.tag }}.exe
@@ -304,7 +304,7 @@ jobs:
         python-version: [3.11]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: ./.github/actions/init-environment
@@ -413,7 +413,7 @@ jobs:
           artifacts: target/AYAB-${{ steps.vars.outputs.tag }}.dmg
           artifactContentType: application/dmg
           replacesArtifacts: true
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: AYAB-${{ steps.vars.outputs.tag }}.dmg
           path: target/AYAB-${{ steps.vars.outputs.tag }}.dmg
@@ -428,7 +428,7 @@ jobs:
         python-version: [3.11]
     steps:
       - name: Checkout repo into AppDir
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
@@ -582,7 +582,7 @@ jobs:
           artifacts: AYAB-${{ steps.vars.outputs.tag }}-x86_64.AppImage
           artifactContentType: application/AppImage
           replacesArtifacts: true
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: AYAB-${{ steps.vars.outputs.tag }}-x86_64.AppImage
           path: AYAB-${{ steps.vars.outputs.tag }}-x86_64.AppImage

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -48,7 +48,7 @@ jobs:
             exit 1
           fi
       - name: Cache firmware
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: src/main/resources/base/ayab/firmware/*.hex
           key: firmware-${{ steps.vars.outputs.manifest }}
@@ -63,37 +63,37 @@ jobs:
           python -m pip install -r requirements.build.txt
       - name: Use cached gui files (1)
         id: gui1-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/*_gui.py
           key: gui1-${{ hashFiles('src/main/python/main/ayab/*_gui.ui') }}
       - name: Use cached gui files (2)
         id: gui2-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/engine/*_gui.py
           key: gui2-${{ hashFiles('src/main/python/main/ayab/engine/*_gui.ui') }}
       - name: Use cached logo
         id: logo-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/ayab_logo_rc.py
           key: logo-${{ hashFiles('src/main/python/main/ayab/ayab_logo_rc.qrc') }}
       - name: Use cached graphics
         id: e-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/engine/*_rc.py
           key: e-${{ hashFiles('src/main/python/main/ayab/engine/*_rc.qrc') }}
       - name: Use cached translation files
         id: qm-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/resources/base/ayab/translations/*.qm
           key: qm-${{ hashFiles('src/main/resources/base/ayab/translations/ayab-translation-master.tsv') }}
       - name: Use cached `base.json` file
         id: base-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/build/settings/base.json
           key: base-${{ steps.vars.outputs.tag }}
@@ -109,37 +109,37 @@ jobs:
           bash setup-environment.ps1
       - name: Cache gui files (1)
         if: ${{ (steps.gui1-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: src/main/python/main/ayab/*_gui.py
           key: gui1-${{ hashFiles('src/main/python/main/ayab/*_gui.ui') }}
       - name: Cache gui files (2)
         if: ${{ (steps.gui2-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: src/main/python/main/ayab/*_gui.py
           key: gui2-${{ hashFiles('src/main/python/main/ayab/engine/*_gui.ui') }}
       - name: Cache logo
         if: ${{ (steps.logo-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: src/main/python/main/ayab/ayab_logo_rc.py
           key: logo-${{ hashFiles('src/main/python/main/ayab/ayab_logo_rc.qrc') }}
       - name: Cache graphics
         if: ${{ (steps.e-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: src/main/python/main/ayab/engine/*_rc.py
           key: e-${{ hashFiles('src/main/python/main/ayab/engine/*_rc.qrc') }}
       - name: Cache translation files
         if: ${{ (steps.qm-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: src/main/resources/base/ayab/translations/*.qm
           key: qm-${{ hashFiles('src/main/resources/base/ayab/translations/ayab-translation-master.tsv') }}
       - name: Cache `base.json` file
         if: ${{ (steps.base-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: src/build/settings/base.json
           key: base-${{ steps.vars.outputs.tag }}
@@ -192,7 +192,7 @@ jobs:
           python -m pip install -r windows-build\windows_build_requirements.txt
       - name: Restore cached firmware
         id: firmware-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/resources/base/ayab/firmware/*.hex
           key: firmware-${{ steps.vars.outputs.manifest }}
@@ -200,7 +200,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Restore cached gui files (1)
         id: gui1-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/*_gui.py
           key: gui1-${{ hashFiles('src/main/python/main/ayab/*_gui.ui') }}
@@ -208,7 +208,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Restore cached gui files (2)
         id: gui2-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/engine/*_gui.py
           key: gui2-${{ hashFiles('src/main/python/main/ayab/engine/*_gui.ui') }}
@@ -216,7 +216,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Restore cached logo
         id: logo-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/ayab_logo_rc.py
           key: logo-${{ hashFiles('src/main/python/main/ayab/ayab_logo_rc.qrc') }}
@@ -224,7 +224,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Restore cached graphics
         id: e-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/engine/*_rc.py
           key: e-${{ hashFiles('src/main/python/main/ayab/engine/*_rc.qrc') }}
@@ -232,7 +232,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Restore cached translation files
         id: qm-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/resources/base/ayab/translations/*.qm
           key: qm-${{ hashFiles('src/main/resources/base/ayab/translations/ayab-translation-master.tsv') }}
@@ -240,7 +240,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Restore cached `base.json` file
         id: base-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/build/settings/base.json
           key: base-${{ steps.vars.outputs.tag }}
@@ -333,49 +333,49 @@ jobs:
           python -m pip install --no-binary charset_normalizer -r requirements.build.txt
       - name: Restore cached firmware
         id: firmware-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/resources/base/ayab/firmware/*.hex
           key: firmware-${{ steps.vars.outputs.manifest }}
           fail-on-cache-miss: true
       - name: Restore cached gui files (1)
         id: gui1-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/*_gui.py
           key: gui1-${{ hashFiles('src/main/python/main/ayab/*_gui.ui') }}
           fail-on-cache-miss: true
       - name: Restore cached gui files (2)
         id: gui2-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/engine/*_gui.py
           key: gui2-${{ hashFiles('src/main/python/main/ayab/engine/*_gui.ui') }}
           fail-on-cache-miss: true
       - name: Restore cached logo
         id: logo-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/ayab_logo_rc.py
           key: logo-${{ hashFiles('src/main/python/main/ayab/ayab_logo_rc.qrc') }}
           fail-on-cache-miss: true
       - name: Restore cached graphics
         id: e-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/engine/*_rc.py
           key: e-${{ hashFiles('src/main/python/main/ayab/engine/*_rc.qrc') }}
           fail-on-cache-miss: true
       - name: Restore cached translation files
         id: qm-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/resources/base/ayab/translations/*.qm
           key: qm-${{ hashFiles('src/main/resources/base/ayab/translations/ayab-translation-master.tsv') }}
           fail-on-cache-miss: true
       - name: Restore cached `base.json` file
         id: base-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/build/settings/base.json
           key: base-${{ steps.vars.outputs.tag }}
@@ -463,49 +463,49 @@ jobs:
           echo "opt/${{steps.vars.outputs.python}}/bin" >> $GITHUB_PATH
       - name: Restore cached firmware
         id: firmware-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/resources/base/ayab/firmware/*.hex
           key: firmware-${{ steps.vars.outputs.manifest }}
           fail-on-cache-miss: true
       - name: Restore cached gui files (1)
         id: gui1-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/*_gui.py
           key: gui1-${{ hashFiles('src/main/python/main/ayab/*_gui.ui') }}
           fail-on-cache-miss: true
       - name: Restore cached gui files (2)
         id: gui2-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/engine/*_gui.py
           key: gui2-${{ hashFiles('src/main/python/main/ayab/engine/*_gui.ui') }}
           fail-on-cache-miss: true
       - name: Restore cached logo
         id: logo-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/ayab_logo_rc.py
           key: logo-${{ hashFiles('src/main/python/main/ayab/ayab_logo_rc.qrc') }}
           fail-on-cache-miss: true
       - name: Restore cached graphics
         id: e-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/python/main/ayab/engine/*_rc.py
           key: e-${{ hashFiles('src/main/python/main/ayab/engine/*_rc.qrc') }}
           fail-on-cache-miss: true
       - name: Restore cached translation files
         id: qm-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/main/resources/base/ayab/translations/*.qm
           key: qm-${{ hashFiles('src/main/resources/base/ayab/translations/ayab-translation-master.tsv') }}
           fail-on-cache-miss: true
       - name: Restore cached `base.json` file
         id: base-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: src/build/settings/base.json
           key: base-${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
Fixes #702 by upgrading `actions/cache` from v3 to v4. In extreme cases like https://github.com/AllYarnsAreBeautiful/ayab-desktop/actions/runs/10762969747/attempts/1 this should cut build time from 30 minutes down to less than 10.

This PR also upgrades `actions/checkout` from v3 to v4, `actions/setup-python` from v4 to v5, `actions/upload-artifact` from v3 to v4, and `DenverCoder1/doxygen-github-pages-action` from v1.3.0 to v1.3.1, which gets rid of warnings that we use old actions requiring Node 16.

There should be no changes in behavior — if something is broken by these upgrades it should show up pretty quickly when doing a build. [Here](https://github.com/jonathanperret/ayab-desktop/actions/runs/10763432802) is a full build I made from this branch — the macOS failure is not new and is being investigated separately (and merging this PR will make it faster to investigate).
