### PR TITLE
Fix macOS build by pinning `delocate`

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -313,7 +313,7 @@ jobs:
         run: |
           brew install avrdude
           mkdir tmp-wheel/
-          python -m pip install delocate
+          python -m pip install delocate==0.11.0
 
           # Find platform values on e.g. https://pypi.org/project/numpy/1.26.4/#files
 

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -310,7 +310,6 @@ jobs:
       - uses: ./.github/actions/init-environment
         id: vars
       - name: Install dependencies
-        shell: zsh {0}
         run: |
           brew install avrdude
           mkdir tmp-wheel/


### PR DESCRIPTION
Fixes #704 by pinning the version of the `delocate` tool we use to create universal Python wheels of dependencies.

It turns out `delocate` released a new release (`0.12.0`) on August 29th. There's a breaking change in that release: the `delocate-fuse` command that our build uses is now hard-deprecated and fails with an error message.

Ideally we'd upgrade to `delocate` `0.12.0` and use the new `delocate-merge` command, but it fails on `numpy` (see https://github.com/matthew-brett/delocate/issues/227), so we'll stick to `0.11.0` for now.

Proof that this fixes the macOS build: https://github.com/jonathanperret/ayab-desktop/actions/runs/10763703517/job/29845535528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the installation command for the `delocate` package to a specific version for improved stability in the workflow.
	- Removed shell specification from the run command to streamline execution in the workflow environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->