### PR TITLE
issue template: put instructions in comments so they don't appear in the issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ Knitting machine:
 AYAB hardware: 
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
 Steps to reproduce the behavior:
@@ -24,10 +24,10 @@ Steps to reproduce the behavior:
 4. See error
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
## 🤔 Problem
Having an issue template is great, but people don't always think to remove the instructions (such as `A clear and concise description of what you expected to happen.`) when filing an issue.

This results in slightly confusing reports where the instructions appear together with the actual issue content. 

## 💡 Proposed solution

Putting the instructions in markdown comment blocks at least prevents them from visually polluting the resulting issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the bug report template to use HTML comments for guidance, enhancing user experience by clarifying instructions without cluttering the visible content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->