### PR TITLE
Execute mypy pre-commit hook in main virtualenv to have access to dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,11 @@ repos:
       hooks:
       -   id: flake8
           additional_dependencies: [flake8-bugbear,flake8-sfs]
-    - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: 'v1.9.0'
+    - repo: local
       hooks:
       -   id: mypy
-          args: [--config-file=.pre-commit.mypy.ini]
-          additional_dependencies: [numpy]
+          name: check types with mypy
+          language: system
+          pass_filenames: false
+          entry: mypy src
+          files: ^src/.*.py$

--- a/.pre-commit.mypy.ini
+++ b/.pre-commit.mypy.ini
@@ -1,6 +1,0 @@
-[mypy]
-plugins =numpy.typing.mypy_plugin
-follow_imports=skip
-ignore_missing_imports=True
-strict=True
-allow_subclassing_any=True


### PR DESCRIPTION
## Problem

Currently, `pre-commit` is configured to run `mypy` in an isolated virtualenv. This causes `mypy` to be unable to see dependencies listed in `requirements.txt` unless they are duplicated into `additional_dependencies` in the `pre-commit` configuration.

Because most dependencies are unavailable in that environment, `mypy` is configured to not follow imports (`follow_imports=skip`) when invoked by `pre-commit`.

This cause `mypy` to give different results on some files when run directly (as is done in the CI workflow) versus through `pre-commit`.

This can easily be demonstrated by running `pre-commit run -a mypy`, which executes the `mypy` hook on all files. Not only are the exclusion patterns written in `mypy.ini` ignored, the differing configuration causes `mypy` to reject `src/main/python/main/ayab/engine/communication.py` for example whereas it is accepted by `mypy` run directly.

Furthermore, that same invocation of `pre-commit` causes `mypy` to crash when invoked on a Python file that imports `numpy`, hitting https://github.com/python/mypy/issues/17396.

To reproduce:

```bash
$ pre-commit clean
Cleaned …/.cache/pre-commit.
$ echo '#test' >> ./src/main/python/main/ayab/utils.py
$ git add ./src/main/python/main/ayab/utils.py
$ pre-commit run mypy
…
[INFO] Installing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

Traceback (most recent call last):
  File "/Users/jonathanperret/.cache/pre-commit/repoayxwybnl/py_env-python3.11/bin/mypy", line 8, in <module>
    sys.exit(console_entry())
             ^^^^^^^^^^^^^^^
  File "/Users/jonathanperret/.cache/pre-commit/repoayxwybnl/py_env-python3.11/lib/python3.11/site-packages/mypy/__main__.py", line 15, in console_entry
    main()
  File "mypy/main.py", line 100, in main
  File "mypy/main.py", line 182, in run_build
  File "mypy/build.py", line 192, in build
  File "mypy/build.py", line 266, in _build
  File "mypy/build.py", line 2942, in dispatch
  File "mypy/build.py", line 3340, in process_graph
  File "mypy/build.py", line 3467, in process_stale_scc
  File "mypy/build.py", line 2503, in write_cache
  File "mypy/build.py", line 1564, in write_cache
  File "mypy/nodes.py", line 387, in serialize
  File "mypy/nodes.py", line 3933, in serialize
  File "mypy/nodes.py", line 3870, in serialize
  File "mypy/nodes.py", line 3301, in serialize
  File "mypy/types.py", line 658, in serialize
  File "mypy/types.py", line 2414, in serialize
  File "mypy/types.py", line 1459, in serialize
  File "mypy/types.py", line 658, in serialize
  File "mypy/types.py", line 3051, in serialize
AssertionError: Internal error: unresolved placeholder type None
```

## Proposed solution

The issues coming from running `mypy` in an isolated `pre-commit` environment are documented in https://github.com/python/mypy/issues/13916 by the `mypy` maintainer.

Two solutions are suggested there: either duplicate all dependencies from `requirements[.build].txt` as `additional_dependencies`, or configure `pre-commit` to execute `mypy` in the project's default virtual environment.

In this PR I opted for the latter option, mainly because it requires less maintenance when dependencies change in the future.

The compromise is that running `mypy` through `pre-commit` will require a properly initialized virtualenv. However because we add a `files:` filter to the `mypy` hook, `pre-commit` will not run if no Python file has been changed; and if Python files have been changed it seems reasonable to expect a proper development environment has been set up.

The `pass_filenames` `pre-commit` option is set to `false` as well, as recommended, so that `mypy` can do whole-project analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the configuration for the type checker from an external repository to a local setup.
	- Removed the previous configuration file, which may affect type checking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->