### PR TITLE
Fix Linux build after python-appimage release disappeared

### DIFF
--- a/.github/actions/init-environment/action.yml
+++ b/.github/actions/init-environment/action.yml
@@ -8,13 +8,19 @@ outputs:
     value: ${{steps.vars.outputs.draft}}
   manifest:
     value: ${{steps.vars.outputs.manifest}}
-  python:
-    value: ${{steps.vars.outputs.python}}
+  python-minor:
+    value: ${{steps.vars.outputs.python-minor}}
   python-appimage:
     value: ${{steps.vars.outputs.python-appimage}}
 runs:
   using: "composite"
   steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      id: py
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: "pip"
     - name: Set variables
       id: vars
       shell: bash
@@ -23,8 +29,8 @@ runs:
         echo "tag=$(git describe --tags)" >> $GITHUB_OUTPUT
         echo "draft=$(git describe --tags | sed -e 's/^test.*/true/;s/^v.*/false/')" >> $GITHUB_OUTPUT
         echo "manifest=$(cat src/main/resources/base/ayab/firmware/manifest.txt)" >> $GITHUB_OUTPUT
-        echo "python=python${{matrix.python-version}}" >> $GITHUB_OUTPUT
-        echo "python-appimage=python${{matrix.python-version}}.9-cp311-cp311-manylinux_2_28_x86_64.AppImage" >> $GITHUB_OUTPUT
+        echo "python-minor=$(echo '${{steps.py.outputs.python-version}}' | sed -e 's/\.[^.]*$//')" >> $GITHUB_OUTPUT
+        echo "python-appimage=python${{steps.py.outputs.python-version}}-cp311-cp311-manylinux_2_28_x86_64.AppImage" >> $GITHUB_OUTPUT
     - name: Set PACKAGE_VERSION
       shell: bash
       run: |
@@ -32,9 +38,3 @@ runs:
         # remove suffix from semver tag, as fbs does not support them
         version_without_suffix=$(echo ${{ steps.vars.outputs.tag }} | sed -E 's/^v?([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
         sed -i -e s/PACKAGE_VERSION/$version_without_suffix/ src/build/settings/base.json
-    - name: Set up Python ${{ matrix.python-version }}
-      id: py
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: "pip"

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.11.9]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -173,7 +173,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.11.9]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -301,7 +301,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.11.9]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -424,7 +424,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.11]
+        # Using Python 3.11.10 specifically for Linux builds due to python-appimage availability
+        python-version: [3.11.10]
     steps:
       - name: Checkout repo into AppDir
         uses: actions/checkout@v4
@@ -440,7 +441,7 @@ jobs:
           cp -r !(git) git
           shopt -u dotglob
       - name: Download AppImage of Python designed for manylinux
-        run: wget -c https://github.com/niess/python-appimage/releases/download/${{steps.vars.outputs.python}}/${{steps.vars.outputs.python-appimage}}
+        run: wget -c https://github.com/niess/python-appimage/releases/download/python${{steps.vars.outputs.python-minor}}/${{steps.vars.outputs.python-appimage}}
       - name: Extract the AppImage
         run: |
           chmod +x ${{steps.vars.outputs.python-appimage}}
@@ -454,12 +455,12 @@ jobs:
           ./AppRun -m pip install --upgrade pip
           ./AppRun -m pip install --upgrade setuptools
           # hack to fix setup.py script with faulty include
-          ./AppRun -m pip install --global-option=build_ext --global-option="-I$(pwd)/opt/${{steps.vars.outputs.python}}/include/${{steps.vars.outputs.python}}" simpleaudio
+          ./AppRun -m pip install --global-option=build_ext --global-option="-I$(pwd)/opt/${{steps.vars.outputs.python-minor}}/include/${{steps.vars.outputs.python-minor}}" simpleaudio
           ./AppRun -m pip install -r requirements.build.txt
       - name: Add AppDir subdirectories to PATH
         run: |
           echo "usr/bin" >> $GITHUB_PATH
-          echo "opt/${{steps.vars.outputs.python}}/bin" >> $GITHUB_PATH
+          echo "opt/${{steps.vars.outputs.python-minor}}/bin" >> $GITHUB_PATH
       - name: Restore cached firmware
         id: firmware-cache
         uses: actions/cache@v4


### PR DESCRIPTION
## Problem

Fixes #721 — at least until `python-appimage` breaks us again.

## Proposed solution

This PR slightly changes the logic used to download the `python-appimage` build: instead of a hardcoded `.9` added to the specified Python version (`3.11`), the build now uses a full Python version (e.g. `3.11.10`) and tries to download a matching `python-appimage` build.

Note that the mismatch between the Python versions used for Windows and macOS (`3.11.9`) on one side, and Linux (`3.11.10`) on the other, is caused by the fact that:
 * a `python-appimage` build is now only available for Python `3.11.10`;
 * `actions/setup-python` cannot install Python `3.11.10` on Windows or macOS (apparently because Python 3.11 is EOL, there are no longer official binaries distributions for the security updates).

Note that because we previously were not specifying the full Python version, these specific versions were already being used by the build.

I'd like to investigate the https://github.com/niess/python-appimage release process a bit more to understand why they remove previously published assets, but for the immediate term this fix should let us continue building AYAB releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity in Python version handling within GitHub Actions workflows.
  
- **Bug Fixes**
	- Updated Python versions in multiple workflows to more specific minor versions, improving consistency and reliability in builds and tests.

- **Chores**
	- Restructured workflow steps for clearer execution order and improved output variable naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->