### PR TITLE
Disable OpenSSL QtNetwork backend to avoid Windows crash

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -268,6 +268,22 @@ jobs:
           pwd
           ls -l src/main/python/main/ayab/
           ls -l src/main/resources/base/ayab/translations/
+
+      # The OpenSSL-based backend for QtNetwork requires the OpenSSL dynamic
+      # libraries but they are not packaged with Qt or PySide. Pyinstaller
+      # tries to find them for us and make them available, but does not
+      # always succeed, see https://github.com/pyinstaller/pyinstaller/issues/8857
+      # What we can do instead is disable the OpenSSL backend by deleting the
+      # relevant plugin — this way, Pyinstaller won't package OpenSSL DLLs,
+      # and Qt will silently fall back to the `schannel` backend that uses
+      # native Windows libraries. Note that deleting the plugin is an approach
+      # that is actually suggested in the Qt documentation, see
+      # https://doc.qt.io/qt-6/ssl.html#considerations-while-packaging-your-application
+      - name: Remove OpenSSL QtNetwork backend
+        shell: bash
+        run: |
+          find "$(python -c 'import PySide6;print(PySide6.__path__[0])')" -iname qopensslbackend.dll -delete
+
       - name: Build app
         shell: pwsh
         run: python -m fbs freeze

--- a/src/main/python/main/ayab/version_checker.py
+++ b/src/main/python/main/ayab/version_checker.py
@@ -25,6 +25,7 @@ class VersionChecker:
         latest_relase_url = f"https://api.github.com/repos/{self.REPO}/releases/latest"
         self.logger.debug("Getting %s", latest_relase_url)
         self._network_manager = QNetworkAccessManager()
+        self._network_manager.setAutoDeleteReplies(True)
         self._version_check_reply = self._network_manager.get(
             QNetworkRequest(latest_relase_url)
         )
@@ -96,5 +97,4 @@ class VersionChecker:
         finally:
             # make sure to free resources once done
             self.logger.debug("Cleaning up")
-            self._version_check_reply = None
             self._network_manager = None


### PR DESCRIPTION
## Problem

Fixes #720.

## Proposed solution

With the help of @Adrienne200 I tracked the crash down to an incorrect OpenSSL DLL being loaded in the AYAB process: instead of the `libssl-3-x64.dll` library bundled with AYAB, the library (on one crashing computer) was being loaded from `C:\Program Files\HP\HP One Agent\libssl-3-x64.dll`!

The reason for the bundled library not being loaded is a PyInstaller bug that I reported: https://github.com/pyinstaller/pyinstaller/issues/8857

We won't need to wait for the fix to PyInstaller though, because in this PR I opted to entirely remove the affected Qt plugin (the OpenSSL-backed QtNetwork backend), as suggested in the Qt documentation when OpenSSL-specific features are not needed: https://doc.qt.io/qt-6/ssl.html#considerations-while-packaging-your-application

## Testing

I created a test release from this PR's head commit: https://github.com/jonathanperret/ayab-desktop/releases/tag/0.99.2-wincrash4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for creating AppImages for Linux, including steps for dependency installation and metadata configuration.
	- Enhanced version checking with improved logging and error handling.

- **Bug Fixes**
	- Refined handling of OpenSSL dependencies on Windows to prevent packaging issues.

- **Chores**
	- Optimized build process by retaining caching mechanisms for various files across jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->