### PR TITLE
Replace simple audio

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -587,8 +587,6 @@ jobs:
           cd squashfs-root
           sudo apt-get install -y avrdude libasound2-dev
           ./AppRun -m pip install --upgrade pip
-          # hack to fix setup.py script with faulty include
-          ./AppRun -m pip install --global-option=build_ext --global-option="-I$(pwd)/opt/${{steps.vars.outputs.python-minor}}/include/${{steps.vars.outputs.python-minor}}" simpleaudio
           ./AppRun -m pip install -r requirements.build.txt
       - name: Add AppDir subdirectories to PATH
         run: |

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,8 +11,6 @@ exclude = (?x)(
 follow_imports= silent
 strict= True
 
-[mypy-simpleaudio]
-ignore_missing_imports= True
 [mypy-sliplib]
 ignore_missing_imports= True
 [mypy-fbs_runtime.*]

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -6,7 +6,6 @@ Pillow==10
 pyserial==3.5
 sliplib==0.6.2
 bitarray==2.9.2
-simpleaudio==1.0.4
 numpy==1.26.4
 charset-normalizer<3.0.0
 semver==3.0.2

--- a/src/main/python/main/ayab/audio.py
+++ b/src/main/python/main/ayab/audio.py
@@ -21,8 +21,8 @@
 
 from __future__ import annotations
 from os import path
-
-import simpleaudio as sa
+from PySide6.QtCore import QUrl
+from PySide6.QtMultimedia import QSoundEffect
 
 from typing import TYPE_CHECKING
 
@@ -34,7 +34,7 @@ class AudioPlayer:
     def __init__(self, gui: GuiMain):
         self.__dir = gui.app_context.get_resource("assets")
         self.__prefs = gui.prefs
-        self.__cache: dict[str, sa.WaveObject] = {}
+        self.__cache: dict[str, QSoundEffect] = {}
 
     def play(self, sound: str) -> None:
         """Play audio."""
@@ -59,4 +59,7 @@ class AudioPlayer:
     def __load_wave(self, sound: str) -> sa.WaveObject | None:
         """Get audio from file."""
         filename = path.join(self.__dir, sound + ".wav")
-        return sa.WaveObject.from_wave_file(filename)
+        print(f"LOAD WAVE: {filename}")
+        effect = QSoundEffect()
+        effect.setSource(QUrl.fromLocalFile(filename))
+        return effect

--- a/src/main/python/main/ayab/audio.py
+++ b/src/main/python/main/ayab/audio.py
@@ -59,7 +59,6 @@ class AudioPlayer:
     def __load_wave(self, sound: str) -> sa.WaveObject | None:
         """Get audio from file."""
         filename = path.join(self.__dir, sound + ".wav")
-        print(f"LOAD WAVE: {filename}")
         effect = QSoundEffect()
         effect.setSource(QUrl.fromLocalFile(filename))
         return effect

--- a/src/main/python/main/ayab/audio.py
+++ b/src/main/python/main/ayab/audio.py
@@ -47,7 +47,7 @@ class AudioPlayer:
         # else
         wave_obj.play()
 
-    def __wave(self, sound: str) -> sa.WaveObject | None:
+    def __wave(self, sound: str) -> QSoundEffect | None:
         """Get and cache audio."""
         if sound not in self.__cache:
             wave_object = self.__load_wave(sound)
@@ -56,7 +56,7 @@ class AudioPlayer:
             self.__cache[sound] = wave_object
         return self.__cache[sound]
 
-    def __load_wave(self, sound: str) -> sa.WaveObject | None:
+    def __load_wave(self, sound: str) -> QSoundEffect | None:
         """Get audio from file."""
         filename = path.join(self.__dir, sound + ".wav")
         effect = QSoundEffect()


### PR DESCRIPTION
This is an attempt to solve the issue https://github.com/AllYarnsAreBeautiful/ayab-desktop/issues/725 by replacing `simpleaudio` with `QSoundEffect` from `PySide6.QtMultimedia`.

It works locally with ubuntu 24.04 and Python 3.12. 
I have also tried to remove all dependencies, but I am not sure if I got everything.

Other versions are currently not tested. If I find time I will try to test it at least under windows.
However this is also some kind of playground for me to figure out how to trigger github actions to build the image from the existing `build-multi-os` workflow. (I have rarely used github at all)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced audio playback using `QSoundEffect` for improved performance and compatibility.
	- Updated caching and deployment processes for building release packages across multiple operating systems.

- **Bug Fixes**
	- Removed the `simpleaudio` dependency, which may affect audio playback functionality.

- **Documentation**
	- Adjustments to configuration files to improve type checking and dependency management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->