### PR TITLE
Synchronise end-of-line sounds between app and firmware

### DIFF
--- a/src/main/python/main/ayab/ayab.py
+++ b/src/main/python/main/ayab/ayab.py
@@ -106,9 +106,7 @@ class GuiMain(QMainWindow):
             self.scene.ayabimage.select_file
         )
         self.ui.cancel_button.clicked.connect(self.engine.cancel)
-        self.hw_test.finished.connect(
-            lambda: self.finish_operation(Operation.TEST, False)
-        )
+        self.hw_test.finished.connect(lambda: self.finish_operation(Operation.TEST))
 
     def __activate_menu(self) -> None:
         self.menu.ui.action_open_image_file.triggered.connect(
@@ -158,7 +156,7 @@ class GuiMain(QMainWindow):
         self.ui.open_image_file_button.setEnabled(False)
         self.menu.setEnabled(False)
 
-    def finish_operation(self, operation: Operation, beep: bool) -> None:
+    def finish_operation(self, operation: Operation) -> None:
         """(Re-)enable UI elements after operation finishes."""
         if operation == Operation.KNIT:
             self.knit_thread.wait()
@@ -168,9 +166,6 @@ class GuiMain(QMainWindow):
         self.ui.filename_lineedit.setEnabled(True)
         self.ui.open_image_file_button.setEnabled(True)
         self.menu.setEnabled(True)
-
-        if operation == Operation.KNIT and beep:
-            self.audio.play("finish")
 
     def set_image_dimensions(self) -> None:
         """Set dimensions of image."""

--- a/src/main/python/main/ayab/engine/communication_mock.py
+++ b/src/main/python/main/ayab/engine/communication_mock.py
@@ -23,20 +23,17 @@ Mock Class of Communication for Test/Simulation purposes
 import logging
 from time import sleep
 
-from PySide6.QtWidgets import QMessageBox
-
 from .communication import Communication, Token
 
 
 class CommunicationMock(Communication):
     """Class Handling the mock communication protocol."""
 
-    def __init__(self, delay=True, step=False) -> None:
+    def __init__(self, delay=True) -> None:
         """Initialize communication."""
         logging.basicConfig(level=logging.DEBUG)
         self.logger = logging.getLogger(type(self).__name__)
         self.__delay = delay
-        self.__step = step
         self.reset()
 
     def __del__(self) -> None:
@@ -122,20 +119,6 @@ class CommunicationMock(Communication):
                 self.rx_msg_list.append(reqLine)
                 if self.__delay:
                     sleep(1)  # wait for knitting progress dialog to update
-                # step through output line by line
-                if self.__step:
-                    # pop up box waits for user input before moving on to next line
-                    msg = QMessageBox()
-                    msg.setIcon(QMessageBox.Icon.Information)
-                    msg.setText("Line number = " + str(self.__line_count))
-                    msg.setStandardButtons(
-                        QMessageBox.StandardButton.Ok
-                        | QMessageBox.StandardButton.Cancel
-                    )
-                    ret = None
-                    ret = msg.exec_()
-                    while ret is None:
-                        pass
             else:
                 self.__started_row = True
         if len(self.rx_msg_list) > 0:

--- a/src/main/python/main/ayab/engine/control.py
+++ b/src/main/python/main/ayab/engine/control.py
@@ -209,9 +209,12 @@ class Control(SignalSender):
         color, row_index, blank_line, last_line = self.mode_func(self, line_number)
         bits = self.select_needles_API6(color, row_index, blank_line)
 
-        # send line to machine
-        flag = last_line and not self.inf_repeat
-        self.com.cnf_line_API6(requested_line, color, flag, bits.tobytes())
+        # Send line to machine
+        # Note that we never set the "final line" flag here, because
+        # we will send an extra blank line afterwards to make sure we
+        # can track the final line being knitted.
+        flags = 0
+        self.com.cnf_line_API6(requested_line, color, flags, bits.tobytes())
 
         # screen output
         # TODO: tidy up this code
@@ -241,6 +244,17 @@ class Control(SignalSender):
             return False  # keep knitting
         else:
             return True  # pattern finished
+
+    def cnf_final_line_API6(self, requested_line: int) -> None:
+        self.logger.debug("sending blank line as final line=%d", requested_line)
+
+        # prepare a blank line as the final line
+        bits = bitarray(self.machine.width, endian="little")
+
+        # send line to machine
+        color = 0  # doesn't matter
+        flags = 1  # this is the last line
+        self.com.cnf_line_API6(requested_line, color, flags, bits.tobytes())
 
     def __update_status(self, line_number: int, color: int, bits: bitarray) -> None:
         self.status.total_rows = self.pat_height

--- a/src/main/python/main/ayab/engine/engine.py
+++ b/src/main/python/main/ayab/engine/engine.py
@@ -20,7 +20,6 @@
 
 from __future__ import annotations
 import logging
-from time import sleep
 from PIL import Image
 
 from PySide6.QtCore import QCoreApplication, Signal
@@ -190,16 +189,12 @@ class Engine(SignalSender, QDockWidget):
             else:
                 # operation == Operation.TEST:
                 self.__logger.info("Finished knitting.")
-            # small delay to finish printing to knit progress window
-            # before "finish.wav" sound plays
-            sleep(1)
         else:
             # TODO: provide translations for these messages
             self.__logger.info("Finished testing.")
 
         # send signal to finish operation
-        # "finish.wav" sound only plays if knitting was not canceled
-        self.emit_operation_finisher(operation, not self.__canceled)
+        self.emit_operation_finisher(operation)
 
     def __handle_status(self) -> None:
         if self.status.active:

--- a/src/main/python/main/ayab/engine/output.py
+++ b/src/main/python/main/ayab/engine/output.py
@@ -100,6 +100,7 @@ class FeedbackHandler(SignalSender):
         self.emit_audio_player("nextline")
 
     def _knitting_finished(self) -> None:
+        self.emit_audio_player("finish")
         self.emit_notification(
             "Image transmission finished. Please knit until you "
             + "hear the double beep sound."

--- a/src/main/python/main/ayab/signal_receiver.py
+++ b/src/main/python/main/ayab/signal_receiver.py
@@ -58,7 +58,7 @@ class SignalReceiver(QObject):
     new_image_flag = Signal()
     bad_config_flag = Signal()
     knitting_starter = Signal()
-    operation_finisher = Signal(Operation, bool)
+    operation_finisher = Signal(Operation)
     hw_test_starter = Signal(Control)
     hw_test_writer = Signal(str)
 

--- a/src/main/python/main/ayab/signal_sender.py
+++ b/src/main/python/main/ayab/signal_sender.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from .signal_receiver import SignalReceiver
     from .utils import MessageTypes
-    from .engine.status import ColorSymbolType, Status
+    from .engine.status import Status
     from .engine.engine_fsm import Operation
     from .engine.options import Alignment
     from .engine.control import Control
@@ -49,12 +49,8 @@ class SignalSender(object):
     def emit_start_row_updater(self, start_row: int) -> None:
         self.__signal_receiver.start_row_updater.emit(start_row)
 
-    def emit_progress_bar_updater(
-        self, status: Status
-    ) -> None:
-        self.__signal_receiver.progress_bar_updater.emit(
-            status
-        )
+    def emit_progress_bar_updater(self, status: Status) -> None:
+        self.__signal_receiver.progress_bar_updater.emit(status)
 
     def emit_knit_progress_updater(
         self, status: Status, row_multiplier: int, midline: int, auto_mirror: bool
@@ -101,8 +97,8 @@ class SignalSender(object):
     def emit_knitting_starter(self) -> None:
         self.__signal_receiver.knitting_starter.emit()
 
-    def emit_operation_finisher(self, operation: Operation, beep: bool) -> None:
-        self.__signal_receiver.operation_finisher.emit(operation, beep)
+    def emit_operation_finisher(self, operation: Operation) -> None:
+        self.__signal_receiver.operation_finisher.emit(operation)
 
     def emit_hw_test_starter(self, control: Control) -> None:
         self.__signal_receiver.hw_test_starter.emit(control)

--- a/src/main/python/main/ayab/tests/test_communication_mock.py
+++ b/src/main/python/main/ayab/tests/test_communication_mock.py
@@ -107,6 +107,9 @@ class TestCommunicationMock(unittest.TestCase):
         )
         self.comm_dummy.update_API6()  # cnfStart
 
+        # Alternates between requesting a line and no output
         for i in range(0, 256):
             bytes_read = self.comm_dummy.update_API6()
             assert bytes_read == (bytearray([Token.reqLine.value, i]), Token.reqLine, i)
+            bytes_read = self.comm_dummy.update_API6()
+            assert bytes_read == (None, Token.none, 0)


### PR DESCRIPTION
## 🤔 Problem

The end-of-line sounds are not synchronized between the firmware and the desktop app, fixes #617.

## 💡 Proposed solution

The main source of discrepancy is the fact that the desktop app closes the connection to the firmware as soon as it has sent the final pattern row. But this actually happens two full carriage passes (or one, with the garter carriage) before knitting is really complete.

The firmware itself continues to emit end-of-row sounds until the end of the last selecting row, i.e. one pass further than the desktop app.

This PR slightly changes the final row transmission logic: instead of marking the last patterning row as "final" and closing the connection, it sends that last row normally (not telling the firmware that it is the last), so that it gets the usual request for a next row from the firmware at the end of that pass, which the app now answers with a blank row.

This which lets the app emit a "work finished" sound at the same point that previous AYAB versions emitted an "end of work" beep from the hardware.

This also makes the message "Please knit until you hear the double beep sound" notification more correct, as the final pass (knitting the final selection of needles while moving them all back to B) will trigger one last sound from the hardware.

Two other minor issues around sounds are also fixed by this PR:
 - the "work finished" sound from the desktop app, in addition to being one pass early as described above, was delayed by one to two seconds — it is now synchronous with the hardware beep, making the app feel more "snappy";
 - the "simulation" mode only emitted end-of-line sounds for the first row, it now more faithfully reproduces the experience of actual knitting.

## 🤔 Remarks

This change may also "fix" #662, or at least reduce its impact — if the firmware now fails to "move on" from the final blank row, the result will be very close to having properly finished the process.

Also, the hardware sounds themselves need a bit of work, as for example the final "double beep sound" does not actually sound like a double beep, at least on the AYAB shield's standard buzzer. I have changes to the firmware that should improve that situation, which I will submit in an upcoming PR to `ayab-firmware`.

## 🔬 How to test

I have prepared a test release at https://github.com/jonathanperret/ayab-desktop/releases/tag/1.0.0-endsounds-4 that can be installed as usual. It does not include a new firmware (compared to 1.0.0 beta 3) so no reflashing should be necessary.

Note that this PR (and the test release above) now includes PR #740 which is a proper fix for #662, so neither it nor #617 should be reproducible on the test release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new `FINISHING` state in the state machine to enhance the knitting operation's control flow.
	- Added audio feedback for knitting completion.

- **Improvements**
	- Simplified signal handling by removing unnecessary parameters from various methods.
	- Enhanced the testing framework for better validation of communication functionality.
	- Improved the efficiency of the knitting operation's completion process.

- **Bug Fixes**
	- Streamlined the operation completion process by removing redundant audio notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->