### PR TITLE
Reset start/stop needle sides when loading an image

### DIFF
--- a/src/main/python/main/ayab/engine/options.py
+++ b/src/main/python/main/ayab/engine/options.py
@@ -228,7 +228,9 @@ class OptionsTab(SignalSender, QWidget):
         Updates the maximum value of the Start Row UI element.
         """
         left_side = width // 2
+        self.ui.start_needle_color.setCurrentIndex(0)  # orange
         self.ui.start_needle_edit.setValue(left_side)
+        self.ui.stop_needle_color.setCurrentIndex(1)  # green
         self.ui.stop_needle_edit.setValue(width - left_side)
         self.ui.start_row_edit.setMaximum(height)
 


### PR DESCRIPTION
## Problem

Fixes #732.

## Proposed solution

Reset start/stop needle sides when loading an image.

## How to test

Try this test release: https://github.com/jonathanperret/ayab-desktop/releases/tag/1.0.0-startstop-side-reset-1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `OptionsTab` to automatically select needle colors when image dimensions are set.
  
- **Bug Fixes**
	- Improved validation logic for `portname` and needle color selection to prevent errors.

- **Improvements**
	- Added restrictions on the number of colors based on selected modes, ensuring clarity in user options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->