### PR TITLE
Fix left/right aligned pattern output

### DIFF
--- a/src/main/python/main/ayab/engine/pattern.py
+++ b/src/main/python/main/ayab/engine/pattern.py
@@ -117,18 +117,16 @@ class Pattern(object):
                         ] = True
 
     def __calc_pat_start_end_needles(self) -> bool:
-        # the sequence of needles is printed in right to left by default
-        # so the needle count starts at 0 on the right hand side
         if self.__alignment == Alignment.CENTER:
             needle_width = self.__knit_end_needle - self.__knit_start_needle
             self.__pat_start_needle = (
                 self.__knit_start_needle + (needle_width - self.pat_width + 1) // 2
             )
             self.__pat_end_needle = self.__pat_start_needle + self.__pat_width
-        elif self.__alignment == Alignment.RIGHT:
+        elif self.__alignment == Alignment.LEFT:
             self.__pat_start_needle = self.__knit_start_needle
             self.__pat_end_needle = self.__pat_start_needle + self.__pat_width
-        elif self.__alignment == Alignment.LEFT:
+        elif self.__alignment == Alignment.RIGHT:
             self.__pat_end_needle = self.__knit_end_needle
             self.__pat_start_needle = self.__pat_end_needle - self.__pat_width
         else:

--- a/src/main/python/main/ayab/tests/test_control.py
+++ b/src/main/python/main/ayab/tests/test_control.py
@@ -259,21 +259,21 @@ class TestControl(unittest.TestCase):
 
         # 40 pixel image set to the left
         control.mode = Mode.SINGLEBED
-        im = Image.new("P", (40, 3), 0)
-        im1 = Image.new("P", (40, 1), 1)
+        im = Image.new("P", (40, 3), 1)
+        im1 = Image.new("P", (40, 1), 0)
         im.paste(im1, (0, 0))
         pattern = Pattern(im, Config(Machine(0), Mode.SINGLEBED), 2)
         pattern.alignment = Alignment.LEFT
+        assert pattern.pat_start_needle == 0
+        assert pattern.pat_end_needle == 40
         control.pattern = pattern
-        assert pattern.pat_start_needle == 160
-        assert pattern.pat_end_needle == 200
-        control.start_needle = 160
-        control.end_needle = 200
+        control.start_needle = 0
+        control.end_needle = 40
         control.start_pixel = 0
         control.end_pixel = 40
         bits0 = bitarray()
         bits0.frombytes(
-            b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+            b"\xff\xff\xff\xff\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
         )
         assert control.select_needles_API6(0, 0, False) == bits0
 


### PR DESCRIPTION
Fixes #734.

There was a leftover from before automatic mirroring was removed.

Test release: https://github.com/jonathanperret/ayab-desktop/releases/tag/1.0.0-fix-alignment-output-1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Adjusted needle position calculations based on updated alignment conditions.

- **Bug Fixes**
	- Updated test cases to reflect changes in needle initialization values and expected outcomes.

- **Tests**
	- Enhanced test logic to accommodate new image configurations and needle settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->