### PR TITLE
Report an unknown carriage in simulation mode 

### DIFF
--- a/src/main/python/main/ayab/engine/communication_mock.py
+++ b/src/main/python/main/ayab/engine/communication_mock.py
@@ -73,11 +73,22 @@ class CommunicationMock(Communication):
         self.rx_msg_list.append(cnfInfo)
 
     def req_init_API6(self, machine_val):
-        """Send machine type."""
+        """Send machine type and initial state report"""
         cnfInit = bytes([Token.cnfInit.value, 0])
         self.rx_msg_list.append(cnfInit)
         indState = bytes(
-            [Token.indState.value, 0, 1, 0xFF, 0xFF, 0xFF, 0xFF, 1, 0x00, 1]
+            [
+                Token.indState.value,
+                0,  # success
+                1,  # fsm state
+                0xFF,
+                0xFF,  # left sensor value
+                0xFF,
+                0xFF,  # right sensor value
+                0xFF,  # carriage type (unknown)
+                0,  # position
+                1,  # direction
+            ]
         )
         self.rx_msg_list.append(indState)
 

--- a/src/main/python/main/ayab/tests/test_communication_mock.py
+++ b/src/main/python/main/ayab/tests/test_communication_mock.py
@@ -73,7 +73,7 @@ class TestCommunicationMock(unittest.TestCase):
         assert bytes_read == expected_result
         # indState shall be sent automatically, also
         expected_result = (
-            bytes([Token.indState.value, 0, 1, 0xFF, 0xFF, 0xFF, 0xFF, 1, 0, 1]),
+            bytes([Token.indState.value, 0, 1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0, 1]),
             Token.indState,
             0,
         )


### PR DESCRIPTION
Fixes #692 as suggested, by reporting an unknown carriage type so that the UI does not show any carriage type.

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/b2ad4c1c-fdd6-4903-ba00-74c28a4dcebb">

Test release: https://github.com/jonathanperret/ayab-desktop/releases/tag/1.0.0-sim-carriage-1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced initialization request now includes detailed machine state information such as sensor values, carriage type, position, and direction.

- **Bug Fixes**
	- Updated test assertions to align with the new expected byte sequence for machine state validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->