### PR TITLE
Send dummy request before closing serial port

### DIFF
--- a/src/main/python/main/ayab/engine/output.py
+++ b/src/main/python/main/ayab/engine/output.py
@@ -33,6 +33,7 @@ class Output(Enum):
     ERROR_INVALID_SETTINGS = auto()
     ERROR_SERIAL_PORT = auto()
     CONNECTING_TO_MACHINE = auto()
+    DISCONNECTING_FROM_MACHINE = auto()
     INITIALIZING_FIRMWARE = auto()
     WAIT_FOR_INIT = auto()
     ERROR_WRONG_API = auto()
@@ -64,6 +65,9 @@ class FeedbackHandler(SignalSender):
 
     def _connecting_to_machine(self) -> None:
         self.emit_notification("Connecting to machine...", False)
+
+    def _disconnecting_from_machine(self) -> None:
+        self.emit_notification("Disconnecting from machine...")
 
     def _initializing_firmware(self) -> None:
         self.emit_notification("Initializing firmware")


### PR DESCRIPTION
## 🐛 Problem

Hopefully fixes #662 .

## 💡 Proposed solution

One theory that is consistent with the observations in #662, is that the last `cnfLine` message sent from the desktop app to the firmware gets lost when the serial port is closed immediately afterwards. Here is an example of this happening in another context: https://github.com/serialport/serialport-rs/issues/117

To avoid closing the serial port before the last data has been received by the firmware, in this PR we add an additional exchange initiated by the desktop app. A `reqInfo` is sent to the firmware, which immediately replies with a `cnfInfo` message. Because messages are sent and received in sequence, receiving this response confirms that previous messages have been transmitted and the serial port can be closed safely.

## 🤔 Alternatives considered

To make sure the last bytes are transmitted, I considered adding a delay before closing the port, but this wouldn't really guarantee data was sent.

A cleaner solution in the longer term would be to evolve the API so that all exchanges would be initiated by the desktop app, instead of having an exception for `reqLine`/`cnfLine`.

## 🔬How to test

This test release includes the change proposed in this PR: https://github.com/jonathanperret/ayab-desktop/releases/tag/1.0.0-safe-disconnect-1
It does not require a new firmware, so no need to reflash before testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `DISCONNECT` state to improve the disconnection process after knitting operations.
	- Added a notification for users indicating that disconnection from the machine is in progress.

- **Improvements**
	- Enhanced feedback mechanism with specific notifications related to the disconnection process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->