### PR TITLE
Linux build: bump to Python 3.11.11

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -440,8 +440,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        # Using Python 3.11.10 specifically for Linux builds due to python-appimage availability
-        python-version: [3.11.10]
+        # Using Python 3.11.11 specifically for Linux builds due to python-appimage availability
+        python-version: [3.11.11]
     steps:
       - name: Checkout repo into AppDir
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

[python-appimage](https://github.com/niess/python-appimage) removed the 3.11.10 release from their repo.

## Proposed solution

Like we did [last time](https://github.com/AllYarnsAreBeautiful/ayab-desktop/pull/722), we bump the version of Python used for the Linux build.

This is not satisfying but right now I don't have a better idea.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced AppImage creation process with new steps for downloading, extracting, and installing dependencies.
  
- **Improvements**
	- Updated Python version for Linux builds to 3.11.11.
	- Standardized caching strategies across all build jobs for consistency.

- **Documentation**
	- Added comments to improve clarity and maintainability of the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->