### PR TITLE
Allow 1.0.0 tag to trigger a release

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -16,7 +16,9 @@ name: Build
 on:
   push:
     tags:
-      - "v?[0-9]+.[0-9]+.[0-9]+-?[a-zA-Z0-9]*"
+      # Not a regex! See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+      - 'v?[0-9]+.[0-9]+.[0-9]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+-[a-zA-Z0-9]+'
 
 jobs:
   setup:
@@ -306,6 +308,8 @@ jobs:
           artifacts: target/AYAB-${{ steps.vars.outputs.tag }}.exe
           artifactContentType: application/exe
           replacesArtifacts: true
+          # Avoid overwriting body that may have been manually edited
+          omitBodyDuringUpdate: true
       - uses: actions/upload-artifact@v4
         with:
           name: AYAB-${{ steps.vars.outputs.tag }}.exe
@@ -428,6 +432,8 @@ jobs:
           artifacts: target/AYAB-${{ steps.vars.outputs.tag }}.dmg
           artifactContentType: application/dmg
           replacesArtifacts: true
+          # Avoid overwriting body that may have been manually edited
+          omitBodyDuringUpdate: true
       - uses: actions/upload-artifact@v4
         with:
           name: AYAB-${{ steps.vars.outputs.tag }}.dmg
@@ -598,6 +604,8 @@ jobs:
           artifacts: AYAB-${{ steps.vars.outputs.tag }}-x86_64.AppImage
           artifactContentType: application/AppImage
           replacesArtifacts: true
+          # Avoid overwriting body that may have been manually edited
+          omitBodyDuringUpdate: true
       - uses: actions/upload-artifact@v4
         with:
           name: AYAB-${{ steps.vars.outputs.tag }}-x86_64.AppImage


### PR DESCRIPTION
## Problem

Creating a `1.0.0` tag does not trigger the creation of a release.

## Cause and proposed solution

There's a subtle error in the tag filter of the `create-release.yml` GitHub Actions workflow.

It ends with `[a-zA-Z0-9]*` to allow a possibly empty release name suffix such as `beta5`. But while this is valid regex syntax, it has a different meaning in the [GitHub Actions filter syntax](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet): there, `[a-zA-Z0-9]` is taken to match one character from the given set, then `*` allows zero or more of any character that is not `/`.

The result is that an empty suffix is not allowed.

The proposed fix in this PR splits the pattern in two variants, one without a suffix and one that has a required suffix.

I tested on my fork that this is sufficient to let non-suffixed tags trigger release creation.

Additionally, this PR copies the `create-release` option used on `ayab-firmware` that avoids overwriting a manually edited release text when CI is adding artifacts from the build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced release version recognition now supports both standard and suffixed version formats.
  - Improved release update process preserves manually edited release details during asset updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->