### PR TITLE
Sign and notarize macOS build

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -321,11 +321,16 @@ jobs:
     name: Create and upload Mac OSX release
     needs: setup
     runs-on: macos-14
+    outputs:
+      tag: ${{ steps.vars.outputs.tag }}
+      submission_id: ${{ steps.notarize.outputs.submission_id }}
+      image_name: ${{ steps.diskimage.outputs.name }}
     strategy:
       matrix:
         python-version: [3.11.9]
     env:
       APPLE_CERTIFICATE_NAME: ${{ secrets.APPLE_CERTIFICATE_NAME }}
+      APPLE_STORE_CONNECT_KEY_ID: ${{ secrets.APPLE_STORE_CONNECT_KEY_ID }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -413,15 +418,18 @@ jobs:
           pwd
           ls -l src/main/python/main/ayab/
           ls -l src/main/resources/base/ayab/translations/
+
       - name: Import Apple developer certificate
         if: env.APPLE_CERTIFICATE_NAME
         uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3
         with:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
           p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+
       - name: Build app
         run: |
           python -m fbs freeze
+
       - name: Sign app
         if: env.APPLE_CERTIFICATE_NAME
         run: |
@@ -432,26 +440,36 @@ jobs:
             -exec codesign -s "$APPLE_CERTIFICATE_NAME" --force --timestamp {} \;
           codesign -s "$APPLE_CERTIFICATE_NAME" --force --all-architectures --timestamp --deep \
             --options=runtime ./target/AYAB-mac.app
-      - name: Create installer
+
+      - name: Create disk image
+        id: diskimage
         run: |
           python -m fbs installer
           mv target/AYAB.dmg target/AYAB-${{ steps.vars.outputs.tag }}.dmg
-      - name: Sign installer
+          echo 'name=AYAB-${{ steps.vars.outputs.tag }}.dmg' >> "$GITHUB_OUTPUT"
+          echo 'path=target/AYAB-${{ steps.vars.outputs.tag }}.dmg' >> "$GITHUB_OUTPUT"
+
+      - name: Sign disk image
         if: env.APPLE_CERTIFICATE_NAME
         run: |
           codesign -s "$APPLE_CERTIFICATE_NAME" --force --all-architectures --timestamp \
-            target/AYAB-${{ steps.vars.outputs.tag }}.dmg
-      - name: Upload asset
+            '${{ steps.diskimage.outputs.path }}'
+
+      - name: Upload signed disk image as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: AYAB-signed-dmg
+          path: ${{ steps.diskimage.outputs.path }}
+
+      - name: Attach disk image (before notarization) to release
         uses: ncipollo/release-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.vars.outputs.tag }}
-          commit: ${{ steps.vars.outputs.sha }}
           # Default to draft and prerelease to let a human check the release before it goes live
           draft: true
           prerelease: false
           allowUpdates: true
-          artifacts: target/AYAB-${{ steps.vars.outputs.tag }}.dmg
+          artifacts: ${{ steps.diskimage.outputs.path }}
           artifactContentType: application/dmg
           replacesArtifacts: true
           # Avoid overwriting a release that may have been manually edited
@@ -459,10 +477,83 @@ jobs:
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitPrereleaseDuringUpdate: true
-      - uses: actions/upload-artifact@v4
+
+      - name: Submit disk image for notarization
+        if: env.APPLE_STORE_CONNECT_KEY_ID
+        id: notarize
+        env:
+          APPLE_STORE_CONNECT_ISSUER: ${{ secrets.APPLE_STORE_CONNECT_ISSUER }}
+          APPLE_STORE_CONNECT_KEY_BASE64: ${{ secrets.APPLE_STORE_CONNECT_KEY_BASE64 }}
+        run: |
+          printenv APPLE_STORE_CONNECT_KEY_BASE64 | base64 --decode > apple-store-connect.key
+
+          # Submit the disk image for notarization
+          SUBMISSION_ID=$(xcrun notarytool submit '${{ steps.diskimage.outputs.path }}' \
+            -k apple-store-connect.key -d "$APPLE_STORE_CONNECT_KEY_ID" -i "$APPLE_STORE_CONNECT_ISSUER" |
+            tee /dev/tty |
+            awk '/id:/ {print $2; exit}')
+
+          echo "submission_id=$SUBMISSION_ID" >> "$GITHUB_OUTPUT"
+
+  staple-macos:
+    name: Wait for notarization to complete and staple ticket to disk image
+    needs: build-macos
+    runs-on: macos-14
+    env:
+      APPLE_STORE_CONNECT_KEY_ID: ${{ secrets.APPLE_STORE_CONNECT_KEY_ID }}
+    steps:
+      - name: Download disk image artifact
+        uses: actions/download-artifact@v4
+        if: env.APPLE_STORE_CONNECT_KEY_ID
         with:
-          name: AYAB-${{ steps.vars.outputs.tag }}.dmg
-          path: target/AYAB-${{ steps.vars.outputs.tag }}.dmg
+          # Will download to a file named ${{ needs.build-macos.outputs.image_name }}
+          name: AYAB-signed-dmg
+
+      - name: Wait for notarization and staple ticket to disk image
+        id: staple
+        if: env.APPLE_STORE_CONNECT_KEY_ID
+        env:
+          APPLE_STORE_CONNECT_ISSUER: ${{ secrets.APPLE_STORE_CONNECT_ISSUER }}
+          APPLE_STORE_CONNECT_KEY_BASE64: ${{ secrets.APPLE_STORE_CONNECT_KEY_BASE64 }}
+        run: |
+          printenv APPLE_STORE_CONNECT_KEY_BASE64 | base64 --decode > apple-store-connect.key
+
+          # Wait for the notarization to complete
+          xcrun notarytool wait '${{ needs.build-macos.outputs.submission_id }}' \
+            -k apple-store-connect.key -d "$APPLE_STORE_CONNECT_KEY_ID" -i "$APPLE_STORE_CONNECT_ISSUER"
+
+          # Print the notarization log for debugging purposes
+          xcrun notarytool log '${{ needs.build-macos.outputs.submission_id }}' \
+            -k apple-store-connect.key -d "$APPLE_STORE_CONNECT_KEY_ID" -i "$APPLE_STORE_CONNECT_ISSUER"
+
+          # Staple the notarization ticket to the disk image
+          xcrun stapler staple -v '${{ needs.build-macos.outputs.image_name }}'
+
+      - name: Upload stapled disk image as artifact
+        uses: actions/upload-artifact@v4
+        if: env.APPLE_STORE_CONNECT_KEY_ID
+        with:
+          name: ${{ needs.build-macos.outputs.image_name }}
+          path: ${{ needs.build-macos.outputs.image_name }}
+
+      - name: Attach disk image (after notarization) to release
+        if: env.APPLE_STORE_CONNECT_KEY_ID
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ needs.build-macos.outputs.tag }}
+          # Default to draft and prerelease to let a human check the release before it goes live
+          draft: true
+          prerelease: false
+          allowUpdates: true
+          artifacts: ${{ needs.build-macos.outputs.image_name }}
+          artifactContentType: application/dmg
+          replacesArtifacts: true
+          # Avoid overwriting a release that may have been manually edited
+          omitNameDuringUpdate: true
+          omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
+
 
   # see https://github.com/AppImage/AppImageKit/wiki/Bundling-Python-apps
   build-appimage:

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -324,6 +324,8 @@ jobs:
     strategy:
       matrix:
         python-version: [3.11.9]
+    env:
+      APPLE_CERTIFICATE_NAME: ${{ secrets.APPLE_CERTIFICATE_NAME }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -411,15 +413,34 @@ jobs:
           pwd
           ls -l src/main/python/main/ayab/
           ls -l src/main/resources/base/ayab/translations/
+      - name: Import Apple developer certificate
+        if: env.APPLE_CERTIFICATE_NAME
+        uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
       - name: Build app
         run: |
           python -m fbs freeze
-          codesign -s - --force --all-architectures --timestamp --deep ./target/AYAB-mac.app
+      - name: Sign app
+        if: env.APPLE_CERTIFICATE_NAME
+        run: |
+          # Sign the avrdude binaries explicitly since `--deep` misses them because they are not
+          # in a directory meant to contain executables.
+          find ./target/AYAB-mac.app/Contents/Resources/ayab/firmware \
+            -type f \( -name avrdude_bin -o -name \*.dylib \) \
+            -exec codesign -s "$APPLE_CERTIFICATE_NAME" --force --timestamp {} \;
+          codesign -s "$APPLE_CERTIFICATE_NAME" --force --all-architectures --timestamp --deep \
+            --options=runtime ./target/AYAB-mac.app
       - name: Create installer
         run: |
           python -m fbs installer
-          codesign -s - --force --all-architectures --timestamp --deep ./target/AYAB.dmg
           mv target/AYAB.dmg target/AYAB-${{ steps.vars.outputs.tag }}.dmg
+      - name: Sign installer
+        if: env.APPLE_CERTIFICATE_NAME
+        run: |
+          codesign -s "$APPLE_CERTIFICATE_NAME" --force --all-architectures --timestamp \
+            target/AYAB-${{ steps.vars.outputs.tag }}.dmg
       - name: Upload asset
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -300,16 +300,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.vars.outputs.tag }}
           commit: ${{ steps.vars.outputs.sha }}
-          body: "" # release message, alternative to body_path
-          # body_path: release_text.md  # uncomment if not used
-          draft: ${{ steps.vars.outputs.draft }}
+          # Default to draft and prerelease to let a human check the release before it goes live
+          draft: true
           prerelease: false
           allowUpdates: true
           artifacts: target/AYAB-${{ steps.vars.outputs.tag }}.exe
           artifactContentType: application/exe
           replacesArtifacts: true
-          # Avoid overwriting body that may have been manually edited
+          # Avoid overwriting a release that may have been manually edited
+          omitNameDuringUpdate: true
           omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
       - uses: actions/upload-artifact@v4
         with:
           name: AYAB-${{ steps.vars.outputs.tag }}.exe
@@ -424,16 +426,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.vars.outputs.tag }}
           commit: ${{ steps.vars.outputs.sha }}
-          body: "" # release message, alternative to body_path
-          # body_path: release_text.md  # uncomment if not used
-          draft: ${{ steps.vars.outputs.draft }}
+          # Default to draft and prerelease to let a human check the release before it goes live
+          draft: true
           prerelease: false
           allowUpdates: true
           artifacts: target/AYAB-${{ steps.vars.outputs.tag }}.dmg
           artifactContentType: application/dmg
           replacesArtifacts: true
-          # Avoid overwriting body that may have been manually edited
+          # Avoid overwriting a release that may have been manually edited
+          omitNameDuringUpdate: true
           omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
       - uses: actions/upload-artifact@v4
         with:
           name: AYAB-${{ steps.vars.outputs.tag }}.dmg
@@ -596,16 +600,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.vars.outputs.tag }}
           commit: ${{ steps.vars.outputs.sha }}
-          body: "" # release message, alternative to body_path
-          # body_path: release_text.md  # uncomment if not used
-          draft: ${{ steps.vars.outputs.draft }}
-          prerelease: false
           allowUpdates: true
           artifacts: AYAB-${{ steps.vars.outputs.tag }}-x86_64.AppImage
           artifactContentType: application/AppImage
           replacesArtifacts: true
-          # Avoid overwriting body that may have been manually edited
+          # Default to draft and prerelease to let a human check the release before it goes live
+          draft: true
+          prerelease: false
+          # Avoid overwriting a release that may have been manually edited
+          omitNameDuringUpdate: true
           omitBodyDuringUpdate: true
+          omitDraftDuringUpdate: true
+          omitPrereleaseDuringUpdate: true
       - uses: actions/upload-artifact@v4
         with:
           name: AYAB-${{ steps.vars.outputs.tag }}-x86_64.AppImage

--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,8 @@ package_version
 documents/
 patterns/
 # Buildfolder
-build/
-target/
+/build/
+/target/
 # macOS
 .DS_Store
 # VSCode

--- a/src/build/settings/mac.json
+++ b/src/build/settings/mac.json
@@ -1,5 +1,5 @@
 {
-    "mac_bundle_identifier": "",
+    "mac_bundle_identifier": "com.ayab-knitting.ayab-desktop",
     "resources_to_filter": [
         "src/main/resources/mac-frozen/Contents/Info.plist"
     ],


### PR DESCRIPTION
Fixes #758 .

## Purpose and implementation

This PR adds code-signing and notarization steps to the macOS build, so that users do not have to manually work around Gatekeeper security measures.

This is dependent on an Apple Developer account, which must be used to generate a number of secrets to be added to the repository, see below.

Because notarization can occasionally take a long time (multiple hours), the main macOS build job only submits the disk image to Apple, then hands control over to another job to wait for notarization to complete. If waiting for notarization fails, that job can be restarted.

## Required secrets

* `APPLE_CERTIFICATE_BASE64`: should contain an Apple **Developer ID** certificate exported as a PKCS#12 (`.p12`) file, encoded in base64.
	* To create the certificate, follow these instructions: https://ioscodesigning.com/generating-code-signing-files/#generate-a-code-signing-certificate — although when the instructions mention `iOS Development` or `iOS Distribution` make sure to select `Developer ID Application` instead. Using Xcode is easier if installed, but the manual process works as well. Stop once you have the certificate in your Keychain, do not generate a provisioning profile.
	* Export the certificate as `.p12` file following this other set of instructions: https://ioscodesigning.com/exporting-code-signing-files/#exporting-certificates . Again, select the `Developer ID Application` certificate type. Use Xcode or the Keychain app. When Xcode/Keychain asks for a password, generate one and write it down.
    * Once you have the `.p12` file, upload it as a secret to this repository. I suggest using the GitHub CLI:
```
base64 < cert.p12 | gh -R AllYarnsAreBeautiful/ayab-desktop secret set APPLE_CERTIFICATE_BASE64
```
* `APPLE_CERTIFICATE_PASSWORD`: set the password you generated when exporting the certificate above.
```
gh -R AllYarnsAreBeautiful/ayab-desktop secret set APPLE_CERTIFICATE_PASSWORD --body "my-secret-password"
```
* `APPLE_CERTIFICATE_NAME`: this is used to select the certificate when signing. Any substring of the certificate name will work, such as `Developer ID` (use the actual string `Developer ID`):
```
gh -R AllYarnsAreBeautiful/ayab-desktop secret set APPLE_CERTIFICATE_NAME --body "Developer ID"
```
* `APPLE_STORE_CONNECT_KEY_BASE64`: an **App Store Connect Team API Key]**.
  * Follow the instructions at https://developer.apple.com/documentation/appstoreconnectapi/creating-api-keys-for-app-store-connect-api#Generate-a-Team-Key-and-Assign-It-a-Role . The key only needs a `Developer` role as that is [sufficient for notarizing](https://developer.apple.com/help/account/manage-your-team/roles/).
  * Copy the key ID, download the generated file, and upload it as a secret:
```
base64 < team.key | gh -R AllYarnsAreBeautiful/ayab-desktop secret set APPLE_STORE_CONNECT_KEY_BASE64
```
* `APPLE_STORE_CONNECT_KEY_ID`: the ID of the **App Store Connect Team API Key]**. Store the ID generated above:
```
gh -R AllYarnsAreBeautiful/ayab-desktop secret set APPLE_STORE_CONNECT_KEY_ID --body "key id"
```
* `APPLE_STORE_CONNECT_ISSUER`: an UUID string that is shared by keys on your App Store Connect account. It should be available on this page: https://appstoreconnect.apple.com/access/integrations/api
```
gh -R AllYarnsAreBeautiful/ayab-desktop secret set APPLE_STORE_CONNECT_ISSUER --body "aaaa-bbbb-cccc…"
```

<!--
@coderabbitai ignore
-->