### PR TITLE
Pin setuptools to known working version to fix Windows crash

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -61,7 +61,6 @@ jobs:
       - name: Install Python modules
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade setuptools
           python -m pip install -r requirements.build.txt
       - name: Use cached gui files (1)
         id: gui1-cache
@@ -189,7 +188,6 @@ jobs:
           choco install patch
           choco install vcredist-all # fixes dependency on msvcr100.dll
           python -m pip install --upgrade pip
-          python -m pip install --upgrade setuptools
           python -m pip install -r requirements.build.txt
           python -m pip install -r windows-build\windows_build_requirements.txt
       - name: Restore cached firmware
@@ -589,7 +587,6 @@ jobs:
           cd squashfs-root
           sudo apt-get install -y avrdude libasound2-dev
           ./AppRun -m pip install --upgrade pip
-          ./AppRun -m pip install --upgrade setuptools
           # hack to fix setup.py script with faulty include
           ./AppRun -m pip install --global-option=build_ext --global-option="-I$(pwd)/opt/${{steps.vars.outputs.python-minor}}/include/${{steps.vars.outputs.python-minor}}" simpleaudio
           ./AppRun -m pip install -r requirements.build.txt

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -1,3 +1,4 @@
+setuptools==75.8.0
 fbs @ git+https://github.com/AllYarnsAreBeautiful/fbs@1.2.1-pyqt6
 PySide6==6.6.2
 PyInstaller==6.4.0


### PR DESCRIPTION
Fixes #762.

Release 75.9.0 of setuptools changed some internal module paths that broke PyInstaller, and other stuff, see https://github.com/pypa/setuptools/issues/4866 for example.

By pinning `setuptools` to a known working version of (the one used to build 1.0 beta 5) we can get a working build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined the build process by removing unnecessary dependency updates.
  - Established a fixed dependency version to enhance overall build consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->