### PR TITLE
fix(translation): Remove "AYAB" translations

### DIFF
--- a/src/main/python/main/ayab/about.py
+++ b/src/main/python/main/ayab/about.py
@@ -36,13 +36,10 @@ class About(QFrame):
 
     def __init__(self, parent: GuiMain):
         super().__init__()
-        self.__version = utils.package_version(parent.app_context)
         self.__ui = Ui_AboutForm()
         self.__ui.setupUi(self)
         self.__ui.title_label.setText(
-            QCoreApplication.translate("MainWindow", "All Yarns Are Beautiful")
-            + " "
-            + self.__version
+            f"AYAB {utils.package_version(parent.app_context)}"
         )
         self.__ui.link_label.setText(
             QCoreApplication.translate("MainWindow", "Website")

--- a/src/main/python/main/ayab/about_gui.ui
+++ b/src/main/python/main/ayab/about_gui.ui
@@ -41,7 +41,7 @@
    <item>
     <widget class="QLabel" name="title_label">
      <property name="text">
-      <string>All Yarns Are Beautiful</string>
+      <string notr="true">AYAB</string>
      </property>
     </widget>
    </item>

--- a/src/main/python/main/ayab/ayab.py
+++ b/src/main/python/main/ayab/ayab.py
@@ -26,6 +26,7 @@ import logging
 from PySide6.QtWidgets import QMainWindow
 from PySide6.QtCore import QCoreApplication
 
+
 from .main_gui import Ui_MainWindow
 from .gui_fsm import gui_fsm
 from .signal_receiver import SignalReceiver
@@ -36,6 +37,7 @@ from .transforms import Transform
 from .firmware_flash import FirmwareFlash
 from .hw_test import HardwareTestDialog
 from .preferences import Preferences
+from . import utils
 
 # from .statusbar import StatusBar
 from .progressbar import ProgressBar
@@ -69,6 +71,8 @@ class GuiMain(QMainWindow):
         # create UI
         self.ui = Ui_MainWindow()
         self.ui.setupUi(self)
+
+        self.setWindowTitle(f"AYAB {utils.package_version(app_context)}")
 
         # add modular components
         self.menu = Menu(self)

--- a/src/main/python/main/ayab/main_gui.ui
+++ b/src/main/python/main/ayab/main_gui.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>All Yarns Are Beautiful</string>
+   <string notr="true">AYAB</string>
   </property>
   <widget class="QWidget" name="central_widget">
    <layout class="QGridLayout" name="grid_layout">

--- a/src/main/resources/base/ayab/translations/ayab-translation-master.tsv
+++ b/src/main/resources/base/ayab/translations/ayab-translation-master.tsv
@@ -31,7 +31,6 @@ StatusTab	progress	progress	Fortschritt	staða	progressione	прогресс	п�
 StatusTab	Center	Centre	Zentriert	Miðja	Centra	По центру	Центр	Centre	Centrar	중앙	中心	中心
 StatusTab	Left	Left	Links	Vinstri	Sinistra	Слева	Ліворуч	Gauche	Izquierda	왼쪽	左	左
 StatusTab	Right	Right	Rechts	Hægri	Destra	Справа	Праворуч	Droite	Derecha	오른쪽	右	右
-MainWindow	All Yarns Are Beautiful	All Yarns Are Beautiful	All Yarns Are Beautiful	Allt Garn Er Fallegt	All Yarns Are Beautiful	Вся пряжа прекрасна	Уся пряжа прекрасна	Tous Les Fils Sont Beaux	Todos Los Hilos Son Hermosos	모든 실은 아름답다	すべての糸は美しいです	诸纱皆妙
 MainWindow	Website	Website	Webseite	Vefsíða	Sito web	Интернет сайт	Веб-сайт	Site Internet	Sitio web	웹사이트	Web サイト	网页
 MainWindow	Manual	Manual	Anleitung	Handbók	Manuale	Справочник	Посібник	Manuel	Manual	매뉴얼	マニュアル	手册
 MainWindow	Assistant	Assistant	Assistent	Aðstoð	Assistente	Помощник	Помічник	Assistant	Asistente	어시스턴트	アシスタント	助手


### PR DESCRIPTION
fixes #764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The application title on the main window and about screen now displays the abbreviated brand label "AYAB" alongside the current version number.
  - The title text is set to not be translated, ensuring consistent branding across all languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->