### PR TITLE
Upgrade `simpleaudio` to an updated fork that supports Python 3.12

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -351,6 +351,10 @@ jobs:
           python -m pip download --only-binary=:all: --platform macosx_11_0_arm64 "$(grep Pillow requirements.build.txt)"
           delocate-fuse Pillow*arm* Pillow*x86* -w tmp-wheel/
 
+          python -m pip download --only-binary=:all: --platform macosx_10_9_x86_64 "$(grep simpleaudio requirements.build.txt)"
+          python -m pip download --only-binary=:all: --platform macosx_11_0_arm64 "$(grep simpleaudio requirements.build.txt)"
+          delocate-fuse simpleaudio*arm* simpleaudio*x86* -w tmp-wheel/
+
           python -m pip download --only-binary=:all: --platform=macosx_10_9_universal2 "$(grep bitarray requirements.build.txt)"
 
           python -m pip install tmp-wheel/*.whl bitarray*.whl

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -6,7 +6,7 @@ Pillow==10
 pyserial==3.5
 sliplib==0.6.2
 bitarray==2.9.2
-simpleaudio==1.0.4
+simpleaudio-patched==1.0.5
 numpy==1.26.4
 charset-normalizer<3.0.0
 semver==3.0.2


### PR DESCRIPTION
## Problem

Fixes #725 (without breaking macOS audio, see #769).

## Proposed solution

We use a fork named `simpleaudio-patched` that is compatible with recent Python versions and has up-to-date binary builds.

## 🔬 Testing

Here's a test build that should be used to check audio works properly on all supported platforms: https://github.com/jonathanperret/ayab-desktop/releases/tag/1.0.1-simpleaudio2

I've tested that this release has correct audio in macOS 15.3.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Enhanced the macOS build process to ensure robust support for audio playback.
	- Updated the audio dependency to a patched version, providing improved performance and compatibility across macOS architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->