### PR TITLE
Revert "Replace simple audio"

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -587,6 +587,8 @@ jobs:
           cd squashfs-root
           sudo apt-get install -y avrdude libasound2-dev
           ./AppRun -m pip install --upgrade pip
+          # hack to fix setup.py script with faulty include
+          ./AppRun -m pip install --global-option=build_ext --global-option="-I$(pwd)/opt/${{steps.vars.outputs.python-minor}}/include/${{steps.vars.outputs.python-minor}}" simpleaudio
           ./AppRun -m pip install -r requirements.build.txt
       - name: Add AppDir subdirectories to PATH
         run: |

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,6 +11,8 @@ exclude = (?x)(
 follow_imports= silent
 strict= True
 
+[mypy-simpleaudio]
+ignore_missing_imports= True
 [mypy-sliplib]
 ignore_missing_imports= True
 [mypy-fbs_runtime.*]

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -6,6 +6,7 @@ Pillow==10
 pyserial==3.5
 sliplib==0.6.2
 bitarray==2.9.2
+simpleaudio==1.0.4
 numpy==1.26.4
 charset-normalizer<3.0.0
 semver==3.0.2

--- a/src/main/python/main/ayab/audio.py
+++ b/src/main/python/main/ayab/audio.py
@@ -21,8 +21,8 @@
 
 from __future__ import annotations
 from os import path
-from PySide6.QtCore import QUrl
-from PySide6.QtMultimedia import QSoundEffect
+
+import simpleaudio as sa
 
 from typing import TYPE_CHECKING
 
@@ -34,7 +34,7 @@ class AudioPlayer:
     def __init__(self, gui: GuiMain):
         self.__dir = gui.app_context.get_resource("assets")
         self.__prefs = gui.prefs
-        self.__cache: dict[str, QSoundEffect] = {}
+        self.__cache: dict[str, sa.WaveObject] = {}
 
     def play(self, sound: str) -> None:
         """Play audio."""
@@ -47,7 +47,7 @@ class AudioPlayer:
         # else
         wave_obj.play()
 
-    def __wave(self, sound: str) -> QSoundEffect | None:
+    def __wave(self, sound: str) -> sa.WaveObject | None:
         """Get and cache audio."""
         if sound not in self.__cache:
             wave_object = self.__load_wave(sound)
@@ -56,9 +56,7 @@ class AudioPlayer:
             self.__cache[sound] = wave_object
         return self.__cache[sound]
 
-    def __load_wave(self, sound: str) -> QSoundEffect | None:
+    def __load_wave(self, sound: str) -> sa.WaveObject | None:
         """Get audio from file."""
         filename = path.join(self.__dir, sound + ".wav")
-        effect = QSoundEffect()
-        effect.setSource(QUrl.fromLocalFile(filename))
-        return effect
+        return sa.WaveObject.from_wave_file(filename)


### PR DESCRIPTION
Reverts AllYarnsAreBeautiful/ayab-desktop#730

As reported by @jonathanperret, this PR breaks audio playback on MacOS in various ways.
Proposed way is to stick with simpleaudio, but a fork, see #771 