### PR TITLE
Remove caching from build

### DIFF
--- a/.github/actions/init-environment/action.yml
+++ b/.github/actions/init-environment/action.yml
@@ -14,6 +14,8 @@ outputs:
     value: ${{steps.vars.outputs.python-minor}}
   python-appimage:
     value: ${{steps.vars.outputs.python-appimage}}
+  firmware-url:
+    value: ${{steps.firmware.outputs.firmware-url}}
 runs:
   using: "composite"
   steps:
@@ -22,7 +24,6 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        cache: "pip"
     - name: Set variables
       id: vars
       shell: bash
@@ -36,6 +37,24 @@ runs:
         echo "manifest=$(cat src/main/resources/base/ayab/firmware/manifest.txt)" >> $GITHUB_OUTPUT
         echo "python-minor=$(echo '${{steps.py.outputs.python-version}}' | sed -e 's/\.[^.]*$//')" >> $GITHUB_OUTPUT
         echo "python-appimage=python${{steps.py.outputs.python-version}}-cp311-cp311-manylinux_2_28_x86_64.AppImage" >> $GITHUB_OUTPUT
+    - name: Get firmware version matching manifest
+      id: firmware
+      shell: bash
+      run: |
+        echo ${{ steps.vars.outputs.manifest }}
+        available=$(curl -s https://github.com/AllYarnsAreBeautiful/ayab-firmware/releases | grep -oE '/tag/[^\"]+' | sed -E 's/\/tag\///')
+        echo $available
+        match=$(for x in $available; do echo $x; done | grep ^${{ steps.vars.outputs.manifest }} | sort -r | head -1)
+        echo $match
+        if [[ $match ]]
+        then
+          cd src/main/resources/base/ayab/firmware/
+          url=https://github.com/AllYarnsAreBeautiful/ayab-firmware/releases/download/$match/ayab_monolithic_uno.hex
+          echo "firmware-url=${url}" >> $GITHUB_OUTPUT
+        else
+          echo "Error: could not find firmware release matching manifest"
+          exit 1
+        fi
     - name: Set PACKAGE_VERSION
       shell: bash
       run: |

--- a/.github/actions/init-environment/action.yml
+++ b/.github/actions/init-environment/action.yml
@@ -34,7 +34,6 @@ runs:
         fi
         echo "sha-short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         echo "tag=$(git describe --tags)" >> $GITHUB_OUTPUT
-        echo "manifest=$(cat src/main/resources/base/ayab/firmware/manifest.txt)" >> $GITHUB_OUTPUT
         echo "python-minor=$(echo '${{steps.py.outputs.python-version}}' | sed -e 's/\.[^.]*$//')" >> $GITHUB_OUTPUT
         echo "python-appimage=python${{steps.py.outputs.python-version}}-cp311-cp311-manylinux_2_28_x86_64.AppImage" >> $GITHUB_OUTPUT
 
@@ -42,11 +41,12 @@ runs:
       id: firmware
       shell: bash
       run: |
-        echo ${{ steps.vars.outputs.manifest }}
+        manifest=$(cat src/main/resources/base/ayab/firmware/manifest.txt)
+        echo "manifest=$manifest"
         available=$(curl -s https://github.com/AllYarnsAreBeautiful/ayab-firmware/releases | grep -oE '/tag/[^\"]+' | sed -E 's/\/tag\///')
-        echo $available
-        match=$(for x in $available; do echo $x; done | grep '^${{ steps.vars.outputs.manifest }}$' | sort -r | head -1)
-        echo $match
+        echo "available=$available"
+        match=$(for x in $available; do echo $x; done | grep "^${manifest}\$" | sort -r | head -1)
+        echo "match=$match"
         if [[ $match ]]
         then
           cd src/main/resources/base/ayab/firmware/

--- a/.github/actions/init-environment/action.yml
+++ b/.github/actions/init-environment/action.yml
@@ -63,4 +63,4 @@ runs:
         echo ${{ steps.vars.outputs.tag }} > src/main/resources/base/ayab/package_version
         # remove suffix from semver tag, as fbs does not support them
         version_without_suffix=$(echo ${{ steps.vars.outputs.tag }} | sed -E 's/^v?([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
-        sed -i -e "s/PACKAGE_VERSION/$version_without_suffix/" src/build/settings/base.json
+        sed -i.bak -e "s/PACKAGE_VERSION/$version_without_suffix/" src/build/settings/base.json

--- a/.github/actions/init-environment/action.yml
+++ b/.github/actions/init-environment/action.yml
@@ -45,7 +45,7 @@ runs:
         echo ${{ steps.vars.outputs.manifest }}
         available=$(curl -s https://github.com/AllYarnsAreBeautiful/ayab-firmware/releases | grep -oE '/tag/[^\"]+' | sed -E 's/\/tag\///')
         echo $available
-        match=$(for x in $available; do echo $x; done | grep ^${{ steps.vars.outputs.manifest }} | sort -r | head -1)
+        match=$(for x in $available; do echo $x; done | grep '^${{ steps.vars.outputs.manifest }}$' | sort -r | head -1)
         echo $match
         if [[ $match ]]
         then

--- a/.github/actions/init-environment/action.yml
+++ b/.github/actions/init-environment/action.yml
@@ -19,11 +19,11 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ env.PYTHON_VERSION }}
       id: py
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ env.PYTHON_VERSION }}
     - name: Set variables
       id: vars
       shell: bash

--- a/.github/actions/init-environment/action.yml
+++ b/.github/actions/init-environment/action.yml
@@ -1,20 +1,20 @@
 name: Init Environment
+description: "Sets up the environment and extracts various build-related variables"
 outputs:
   do-release:
+    description: "'true' if the current ref is a release tag (matches semver pattern)"
     value: ${{steps.vars.outputs.do-release}}
-  sha-short:
-    value: ${{steps.vars.outputs.sha-short}}
   tag:
+    description: "Current Git tag from git describe"
     value: ${{steps.vars.outputs.tag}}
-  draft:
-    value: ${{steps.vars.outputs.draft}}
-  manifest:
-    value: ${{steps.vars.outputs.manifest}}
   python-minor:
+    description: "Python version without patch number (e.g. 3.11)"
     value: ${{steps.vars.outputs.python-minor}}
   python-appimage:
+    description: "Python AppImage filename for Linux builds"
     value: ${{steps.vars.outputs.python-appimage}}
   firmware-url:
+    description: "Download URL for the firmware hex file"
     value: ${{steps.firmware.outputs.firmware-url}}
 runs:
   using: "composite"
@@ -24,6 +24,7 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
+
     - name: Set variables
       id: vars
       shell: bash
@@ -33,10 +34,10 @@ runs:
         fi
         echo "sha-short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         echo "tag=$(git describe --tags)" >> $GITHUB_OUTPUT
-        echo "draft=$(git describe --tags | sed -e 's/^test.*/true/;s/^v.*/false/')" >> $GITHUB_OUTPUT
         echo "manifest=$(cat src/main/resources/base/ayab/firmware/manifest.txt)" >> $GITHUB_OUTPUT
         echo "python-minor=$(echo '${{steps.py.outputs.python-version}}' | sed -e 's/\.[^.]*$//')" >> $GITHUB_OUTPUT
         echo "python-appimage=python${{steps.py.outputs.python-version}}-cp311-cp311-manylinux_2_28_x86_64.AppImage" >> $GITHUB_OUTPUT
+
     - name: Get firmware version matching manifest
       id: firmware
       shell: bash
@@ -55,6 +56,7 @@ runs:
           echo "Error: could not find firmware release matching manifest"
           exit 1
         fi
+
     - name: Set PACKAGE_VERSION
       shell: bash
       run: |

--- a/.github/actions/init-environment/action.yml
+++ b/.github/actions/init-environment/action.yml
@@ -1,5 +1,7 @@
 name: Init Environment
 outputs:
+  do-release:
+    value: ${{steps.vars.outputs.do-release}}
   sha-short:
     value: ${{steps.vars.outputs.sha-short}}
   tag:
@@ -25,6 +27,9 @@ runs:
       id: vars
       shell: bash
       run: |
+        if [[ "$GITHUB_REF" =~ ^refs/tags/v?[0-9]+\.[0-9]+\.[0-9]+-?[-a-zA-Z0-9]*$ ]]; then
+            echo "do-release=true" >> $GITHUB_OUTPUT
+        fi
         echo "sha-short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         echo "tag=$(git describe --tags)" >> $GITHUB_OUTPUT
         echo "draft=$(git describe --tags | sed -e 's/^test.*/true/;s/^v.*/false/')" >> $GITHUB_OUTPUT
@@ -37,4 +42,4 @@ runs:
         echo ${{ steps.vars.outputs.tag }} > src/main/resources/base/ayab/package_version
         # remove suffix from semver tag, as fbs does not support them
         version_without_suffix=$(echo ${{ steps.vars.outputs.tag }} | sed -E 's/^v?([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
-        sed -i -e s/PACKAGE_VERSION/$version_without_suffix/ src/build/settings/base.json
+        sed -i -e "s/PACKAGE_VERSION/$version_without_suffix/" src/build/settings/base.json

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -186,12 +186,18 @@ jobs:
           python -m fbs freeze
 
       - name: Sign app
-        if: env.APPLE_CERTIFICATE_NAME
+        shell: bash
         run: |
-          # Sign the avrdude binary explicitly since `--deep` misses it because it is not
-          # in a directory meant to contain executables.
-          codesign -s "$APPLE_CERTIFICATE_NAME" --force --all-architectures \
-            --timestamp --deep --options=runtime \
+          # - If an actual certificate is not available, we default the identity to "-" to enable
+          #   ad-hoc signing, and disable the hardened runtime.
+          # - We sign the `avrdude_mac` binary explicitly since `--deep` misses it because it
+          #   is not in a directory meant to contain executables.
+          codesign_identity=${APPLE_CERTIFICATE_NAME:-"-"}
+          if [[ -n "$APPLE_CERTIFICATE_NAME" ]]; then
+            codesign_options="--options=runtime"
+          fi
+          codesign -s "$codesign_identity" $codesign_options \
+            --force --all-architectures --timestamp --deep \
             ./target/AYAB-mac.app/Contents/Resources/ayab/firmware/avrdude_mac \
             ./target/AYAB-mac.app
 

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -16,131 +16,6 @@ name: Build
 on: [push, pull_request]
 
 jobs:
-  setup:
-    name: Create cache
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        python-version: [3.11.9]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0 # necessary for `git describe`
-      - uses: ./.github/actions/init-environment
-        id: vars
-      - name: Get firmware version matching manifest
-        run: |
-          echo ${{ steps.vars.outputs.manifest }}
-          available=$(curl -s https://github.com/AllYarnsAreBeautiful/ayab-firmware/releases | grep -oE '/tag/[^\"]+' | sed -E 's/\/tag\///')
-          echo $available
-          match=$(for x in $available; do echo $x; done | grep ^${{ steps.vars.outputs.manifest }} | sort -r | head -1)
-          echo $match
-          if [[ $match ]]
-          then
-            cd src/main/resources/base/ayab/firmware/
-            wget https://github.com/AllYarnsAreBeautiful/ayab-firmware/releases/download/$match/ayab_monolithic_uno.hex
-          else
-            echo "Error: could not find firmware release matching manifest"
-            exit 1
-          fi
-      - name: Cache firmware
-        uses: actions/cache/save@v4
-        with:
-          path: src/main/resources/base/ayab/firmware/*.hex
-          key: firmware-${{ steps.vars.outputs.manifest }}
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt-get install -y avrdude libasound2-dev
-      - name: Install Python modules
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.build.txt
-      - name: Use cached gui files (1)
-        id: gui1-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/*_gui.py
-          key: gui1-${{ hashFiles('src/main/python/main/ayab/*_gui.ui') }}
-      - name: Use cached gui files (2)
-        id: gui2-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/engine/*_gui.py
-          key: gui2-${{ hashFiles('src/main/python/main/ayab/engine/*_gui.ui') }}
-      - name: Use cached logo
-        id: logo-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/ayab_logo_rc.py
-          key: logo-${{ hashFiles('src/main/python/main/ayab/ayab_logo_rc.qrc') }}
-      - name: Use cached graphics
-        id: e-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/engine/*_rc.py
-          key: e-${{ hashFiles('src/main/python/main/ayab/engine/*_rc.qrc') }}
-      - name: Use cached translation files
-        id: qm-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/resources/base/ayab/translations/*.qm
-          key: qm-${{ hashFiles('src/main/resources/base/ayab/translations/ayab-translation-master.tsv') }}
-      - name: Use cached `base.json` file
-        id: base-cache
-        uses: actions/cache@v4
-        with:
-          path: src/build/settings/base.json
-          key: base-${{ steps.vars.outputs.tag }}
-      - name: Convert UI and translation files
-        if: ${{ (steps.gui1-cache.outputs.cache-hit != 'true') ||
-          (steps.gui2-cache.outputs.cache-hit != 'true') ||
-          (steps.logo-cache.outputs.cache-hit != 'true') ||
-          (steps.e-cache.outputs.cache-hit    != 'true') ||
-          (steps.qm-cache.outputs.cache-hit   != 'true') }}
-        run: |
-          # Install qt6 packages to bring in system dependencies only
-          sudo apt install -y qt6-base-dev qt6-tools-dev-tools
-          bash setup-environment.ps1
-      - name: Cache gui files (1)
-        if: ${{ (steps.gui1-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v4
-        with:
-          path: src/main/python/main/ayab/*_gui.py
-          key: gui1-${{ hashFiles('src/main/python/main/ayab/*_gui.ui') }}
-      - name: Cache gui files (2)
-        if: ${{ (steps.gui2-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v4
-        with:
-          path: src/main/python/main/ayab/*_gui.py
-          key: gui2-${{ hashFiles('src/main/python/main/ayab/engine/*_gui.ui') }}
-      - name: Cache logo
-        if: ${{ (steps.logo-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v4
-        with:
-          path: src/main/python/main/ayab/ayab_logo_rc.py
-          key: logo-${{ hashFiles('src/main/python/main/ayab/ayab_logo_rc.qrc') }}
-      - name: Cache graphics
-        if: ${{ (steps.e-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v4
-        with:
-          path: src/main/python/main/ayab/engine/*_rc.py
-          key: e-${{ hashFiles('src/main/python/main/ayab/engine/*_rc.qrc') }}
-      - name: Cache translation files
-        if: ${{ (steps.qm-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v4
-        with:
-          path: src/main/resources/base/ayab/translations/*.qm
-          key: qm-${{ hashFiles('src/main/resources/base/ayab/translations/ayab-translation-master.tsv') }}
-      - name: Cache `base.json` file
-        if: ${{ (steps.base-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v4
-        with:
-          path: src/build/settings/base.json
-          key: base-${{ steps.vars.outputs.tag }}
-
   deploy:
     name: Create and deploy source code documentation
     runs-on: ubuntu-22.04
@@ -166,7 +41,6 @@ jobs:
 
   build-windows:
     name: Create and upload Windows release
-    needs: setup
     runs-on: windows-latest
     strategy:
       matrix:
@@ -179,70 +53,21 @@ jobs:
           fetch-depth: 0 # necessary for `git describe`
       - uses: ./.github/actions/init-environment
         id: vars
+      - name: Get firmware version matching manifest
+        shell: bash
+        working-directory: src/main/resources/base/ayab/firmware/
+        run: |
+          curl -O ${{ steps.vars.outputs.firmware-url }}
       - name: Install dependencies
         shell: pwsh
         run: |
-          choco install patch
           choco install vcredist-all # fixes dependency on msvcr100.dll
           python -m pip install --upgrade pip
           python -m pip install -r requirements.build.txt
           python -m pip install -r windows-build\windows_build_requirements.txt
-      - name: Restore cached firmware
-        id: firmware-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/resources/base/ayab/firmware/*.hex
-          key: firmware-${{ steps.vars.outputs.manifest }}
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
-      - name: Restore cached gui files (1)
-        id: gui1-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/*_gui.py
-          key: gui1-${{ hashFiles('src/main/python/main/ayab/*_gui.ui') }}
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
-      - name: Restore cached gui files (2)
-        id: gui2-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/engine/*_gui.py
-          key: gui2-${{ hashFiles('src/main/python/main/ayab/engine/*_gui.ui') }}
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
-      - name: Restore cached logo
-        id: logo-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/ayab_logo_rc.py
-          key: logo-${{ hashFiles('src/main/python/main/ayab/ayab_logo_rc.qrc') }}
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
-      - name: Restore cached graphics
-        id: e-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/engine/*_rc.py
-          key: e-${{ hashFiles('src/main/python/main/ayab/engine/*_rc.qrc') }}
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
-      - name: Restore cached translation files
-        id: qm-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/resources/base/ayab/translations/*.qm
-          key: qm-${{ hashFiles('src/main/resources/base/ayab/translations/ayab-translation-master.tsv') }}
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
-      - name: Restore cached `base.json` file
-        id: base-cache
-        uses: actions/cache@v4
-        with:
-          path: src/build/settings/base.json
-          key: base-${{ steps.vars.outputs.tag }}
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
+      - name: Convert UI and translation files
+        run: |
+          bash setup-environment.ps1
       - name: Remove unneeded files
         shell: bash
         run: |
@@ -259,12 +84,6 @@ jobs:
           do
             unix2dos $f
           done
-      - name: Check cached files
-        shell: bash
-        run: |
-          pwd
-          ls -l src/main/python/main/ayab/
-          ls -l src/main/resources/base/ayab/translations/
 
       # The OpenSSL-based backend for QtNetwork requires the OpenSSL dynamic
       # libraries but they are not packaged with Qt or PySide. Pyinstaller
@@ -315,7 +134,6 @@ jobs:
 
   build-macos:
     name: Create and upload Mac OSX release
-    needs: setup
     runs-on: macos-14
     outputs:
       tag: ${{ steps.vars.outputs.tag }}
@@ -335,6 +153,11 @@ jobs:
           fetch-depth: 0 # necessary for `git describe`
       - uses: ./.github/actions/init-environment
         id: vars
+      - name: Get firmware version matching manifest
+        shell: bash
+        working-directory: src/main/resources/base/ayab/firmware/
+        run: |
+          curl -O ${{ steps.vars.outputs.firmware-url }}
       - name: Install dependencies
         run: |
           mkdir tmp-wheel/
@@ -359,65 +182,13 @@ jobs:
           python -m pip install tmp-wheel/*.whl bitarray*.whl
 
           python -m pip install --no-binary charset_normalizer -r requirements.build.txt
-      - name: Restore cached firmware
-        id: firmware-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/resources/base/ayab/firmware/*.hex
-          key: firmware-${{ steps.vars.outputs.manifest }}
-          fail-on-cache-miss: true
-      - name: Restore cached gui files (1)
-        id: gui1-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/*_gui.py
-          key: gui1-${{ hashFiles('src/main/python/main/ayab/*_gui.ui') }}
-          fail-on-cache-miss: true
-      - name: Restore cached gui files (2)
-        id: gui2-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/engine/*_gui.py
-          key: gui2-${{ hashFiles('src/main/python/main/ayab/engine/*_gui.ui') }}
-          fail-on-cache-miss: true
-      - name: Restore cached logo
-        id: logo-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/ayab_logo_rc.py
-          key: logo-${{ hashFiles('src/main/python/main/ayab/ayab_logo_rc.qrc') }}
-          fail-on-cache-miss: true
-      - name: Restore cached graphics
-        id: e-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/engine/*_rc.py
-          key: e-${{ hashFiles('src/main/python/main/ayab/engine/*_rc.qrc') }}
-          fail-on-cache-miss: true
-      - name: Restore cached translation files
-        id: qm-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/resources/base/ayab/translations/*.qm
-          key: qm-${{ hashFiles('src/main/resources/base/ayab/translations/ayab-translation-master.tsv') }}
-          fail-on-cache-miss: true
-      - name: Restore cached `base.json` file
-        id: base-cache
-        uses: actions/cache@v4
-        with:
-          path: src/build/settings/base.json
-          key: base-${{ steps.vars.outputs.tag }}
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
+      - name: Convert UI and translation files
+        run: |
+          bash setup-environment.ps1
       - name: Remove unneeded files
         run: |
           rm src/main/python/main/ayab/*_gui.ui
           rm src/main/python/main/ayab/ayab_logo_rc.qrc
-      - name: Check cached files
-        run: |
-          pwd
-          ls -l src/main/python/main/ayab/
-          ls -l src/main/resources/base/ayab/translations/
 
       - name: Import Apple developer certificate
         if: env.APPLE_CERTIFICATE_NAME
@@ -558,7 +329,6 @@ jobs:
   # see https://github.com/AppImage/AppImageKit/wiki/Bundling-Python-apps
   build-appimage:
     name: Create and upload Linux AppImage release
-    needs: setup
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -572,6 +342,20 @@ jobs:
           fetch-depth: 0 # necessary for `git describe`
       - uses: ./.github/actions/init-environment
         id: vars
+      - name: Get firmware version matching manifest
+        shell: bash
+        working-directory: src/main/resources/base/ayab/firmware/
+        run: |
+          curl -O ${{ steps.vars.outputs.firmware-url }}
+      - name: Install Python modules
+        run: |
+          sudo apt-get install -y avrdude libasound2-dev
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
+          python -m pip install -r requirements.build.txt
+      - name: Convert UI and translation files
+        run: |
+          bash setup-environment.ps1
       - name: Relocate
         run: |
           mkdir git
@@ -598,77 +382,12 @@ jobs:
         run: |
           echo "usr/bin" >> $GITHUB_PATH
           echo "opt/${{steps.vars.outputs.python-minor}}/bin" >> $GITHUB_PATH
-      - name: Restore cached firmware
-        id: firmware-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/resources/base/ayab/firmware/*.hex
-          key: firmware-${{ steps.vars.outputs.manifest }}
-          fail-on-cache-miss: true
-      - name: Restore cached gui files (1)
-        id: gui1-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/*_gui.py
-          key: gui1-${{ hashFiles('src/main/python/main/ayab/*_gui.ui') }}
-          fail-on-cache-miss: true
-      - name: Restore cached gui files (2)
-        id: gui2-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/engine/*_gui.py
-          key: gui2-${{ hashFiles('src/main/python/main/ayab/engine/*_gui.ui') }}
-          fail-on-cache-miss: true
-      - name: Restore cached logo
-        id: logo-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/ayab_logo_rc.py
-          key: logo-${{ hashFiles('src/main/python/main/ayab/ayab_logo_rc.qrc') }}
-          fail-on-cache-miss: true
-      - name: Restore cached graphics
-        id: e-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/python/main/ayab/engine/*_rc.py
-          key: e-${{ hashFiles('src/main/python/main/ayab/engine/*_rc.qrc') }}
-          fail-on-cache-miss: true
-      - name: Restore cached translation files
-        id: qm-cache
-        uses: actions/cache@v4
-        with:
-          path: src/main/resources/base/ayab/translations/*.qm
-          key: qm-${{ hashFiles('src/main/resources/base/ayab/translations/ayab-translation-master.tsv') }}
-          fail-on-cache-miss: true
-      - name: Restore cached `base.json` file
-        id: base-cache
-        uses: actions/cache@v4
-        with:
-          path: src/build/settings/base.json
-          key: base-${{ steps.vars.outputs.tag }}
-          enableCrossOsArchive: true
-          fail-on-cache-miss: true
-      - name: Move cached files
-        run: |
-          mv src/main/resources/base/ayab/firmware/*.hex squashfs-root/src/main/resources/base/ayab/firmware/
-          mv src/main/python/main/ayab/*_gui.py squashfs-root/src/main/python/main/ayab/
-          mv src/main/python/main/ayab/engine/*_gui.py squashfs-root/src/main/python/main/ayab/engine/
-          mv src/main/python/main/ayab/ayab_logo_rc.py squashfs-root/src/main/python/main/ayab/
-          mv src/main/python/main/ayab/engine/lowercase_e_rc.py squashfs-root/src/main/python/main/ayab/engine
-          mv src/main/python/main/ayab/engine/lowercase_e_reversed_rc.py squashfs-root/src/main/python/main/ayab/engine
-          mv src/main/resources/base/ayab/translations/*.qm squashfs-root/src/main/resources/base/ayab/translations/
-          mv src/build/settings/base.json squashfs-root/src/build/settings/base.json
       - name: Remove unneeded files
         run: |
           rm squashfs-root/src/main/python/main/ayab/*_gui.ui
           rm squashfs-root/src/main/python/main/ayab/ayab_logo_rc.qrc
           rm squashfs-root/src/main/python/main/ayab/engine/lowercase_e_rc.qrc
           rm squashfs-root/src/main/python/main/ayab/engine/lowercase_e_reversed_rc.qrc
-      - name: Check cached files
-        run: |
-          pwd
-          ls -l squashfs-root/src/main/python/main/ayab/
-          ls -l squashfs-root/src/main/resources/base/ayab/translations/
       - name: Replace AppRun
         run: |
           cd squashfs-root

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         shell: pwsh
         run: |
-          choco install vcredist-all # fixes dependency on msvcr100.dll
+          choco install vcredist2010 # fixes dependency on msvcr100.dll
           python -m pip install --upgrade pip
           python -m pip install -r requirements.build.txt
           python -m pip install -r windows-build\windows_build_requirements.txt

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -135,10 +135,6 @@ jobs:
   build-macos:
     name: Create and upload Mac OSX release
     runs-on: macos-14
-    outputs:
-      tag: ${{ steps.vars.outputs.tag }}
-      submission_id: ${{ steps.notarize.outputs.submission_id }}
-      image_name: ${{ steps.diskimage.outputs.name }}
     env:
       APPLE_CERTIFICATE_NAME: ${{ secrets.APPLE_CERTIFICATE_NAME }}
       APPLE_STORE_CONNECT_KEY_ID: ${{ secrets.APPLE_STORE_CONNECT_KEY_ID }}
@@ -217,18 +213,34 @@ jobs:
           echo 'path=target/AYAB-${{ steps.vars.outputs.tag }}.dmg' >> "$GITHUB_OUTPUT"
 
       - name: Sign disk image
-        if: env.APPLE_CERTIFICATE_NAME
+        if: steps.vars.outputs.do-release == 'true' && env.APPLE_CERTIFICATE_NAME
         run: |
           codesign -s "$APPLE_CERTIFICATE_NAME" --force --all-architectures --timestamp \
             '${{ steps.diskimage.outputs.path }}'
 
-      - name: Upload signed disk image as artifact
+      - name: Submit disk image for notarization
+        if: steps.vars.outputs.do-release == 'true' && env.APPLE_STORE_CONNECT_KEY_ID
+        env:
+          APPLE_STORE_CONNECT_ISSUER: ${{ secrets.APPLE_STORE_CONNECT_ISSUER }}
+          APPLE_STORE_CONNECT_KEY_BASE64: ${{ secrets.APPLE_STORE_CONNECT_KEY_BASE64 }}
+        run: |
+          printenv APPLE_STORE_CONNECT_KEY_BASE64 | base64 --decode > apple-store-connect.key
+
+          # Submit the disk image for notarization and wait
+          xcrun notarytool submit '${{ steps.diskimage.outputs.path }}' \
+            -k apple-store-connect.key -d "$APPLE_STORE_CONNECT_KEY_ID" -i "$APPLE_STORE_CONNECT_ISSUER" \
+            --wait
+
+          # Staple the notarization ticket to the disk image
+          xcrun stapler staple -v '${{ steps.diskimage.outputs.path }}'
+
+      - name: Upload disk image as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: AYAB-signed-dmg
+          name: ${{ steps.diskimage.outputs.name }}
           path: ${{ steps.diskimage.outputs.path }}
 
-      - name: Attach disk image (before notarization) to release
+      - name: Attach disk image to release
         uses: ncipollo/release-action@v1
         if: steps.vars.outputs.do-release == 'true'
         with:
@@ -245,83 +257,6 @@ jobs:
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitPrereleaseDuringUpdate: true
-
-      - name: Submit disk image for notarization
-        if: env.APPLE_STORE_CONNECT_KEY_ID
-        id: notarize
-        env:
-          APPLE_STORE_CONNECT_ISSUER: ${{ secrets.APPLE_STORE_CONNECT_ISSUER }}
-          APPLE_STORE_CONNECT_KEY_BASE64: ${{ secrets.APPLE_STORE_CONNECT_KEY_BASE64 }}
-        run: |
-          printenv APPLE_STORE_CONNECT_KEY_BASE64 | base64 --decode > apple-store-connect.key
-
-          # Submit the disk image for notarization
-          SUBMISSION_ID=$(xcrun notarytool submit '${{ steps.diskimage.outputs.path }}' \
-            -k apple-store-connect.key -d "$APPLE_STORE_CONNECT_KEY_ID" -i "$APPLE_STORE_CONNECT_ISSUER" |
-            tee /dev/stderr |
-            awk '/id:/ {print $2; exit}')
-
-          echo "submission_id=$SUBMISSION_ID" >> "$GITHUB_OUTPUT"
-
-  staple-macos:
-    name: Wait for notarization to complete and staple ticket to disk image
-    needs: build-macos
-    runs-on: macos-14
-    env:
-      APPLE_STORE_CONNECT_KEY_ID: ${{ secrets.APPLE_STORE_CONNECT_KEY_ID }}
-    steps:
-      - name: Download disk image artifact
-        uses: actions/download-artifact@v4
-        if: env.APPLE_STORE_CONNECT_KEY_ID
-        with:
-          # Will download to a file named ${{ needs.build-macos.outputs.image_name }}
-          name: AYAB-signed-dmg
-
-      - name: Wait for notarization and staple ticket to disk image
-        id: staple
-        if: env.APPLE_STORE_CONNECT_KEY_ID
-        env:
-          APPLE_STORE_CONNECT_ISSUER: ${{ secrets.APPLE_STORE_CONNECT_ISSUER }}
-          APPLE_STORE_CONNECT_KEY_BASE64: ${{ secrets.APPLE_STORE_CONNECT_KEY_BASE64 }}
-        run: |
-          printenv APPLE_STORE_CONNECT_KEY_BASE64 | base64 --decode > apple-store-connect.key
-
-          # Wait for the notarization to complete
-          xcrun notarytool wait '${{ needs.build-macos.outputs.submission_id }}' \
-            -k apple-store-connect.key -d "$APPLE_STORE_CONNECT_KEY_ID" -i "$APPLE_STORE_CONNECT_ISSUER"
-
-          # Print the notarization log for debugging purposes
-          xcrun notarytool log '${{ needs.build-macos.outputs.submission_id }}' \
-            -k apple-store-connect.key -d "$APPLE_STORE_CONNECT_KEY_ID" -i "$APPLE_STORE_CONNECT_ISSUER"
-
-          # Staple the notarization ticket to the disk image
-          xcrun stapler staple -v '${{ needs.build-macos.outputs.image_name }}'
-
-      - name: Upload stapled disk image as artifact
-        uses: actions/upload-artifact@v4
-        if: env.APPLE_STORE_CONNECT_KEY_ID
-        with:
-          name: ${{ needs.build-macos.outputs.image_name }}
-          path: ${{ needs.build-macos.outputs.image_name }}
-
-      - name: Attach disk image (after notarization) to release
-        if: env.APPLE_STORE_CONNECT_KEY_ID
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ needs.build-macos.outputs.tag }}
-          # Default to draft and prerelease to let a human check the release before it goes live
-          draft: true
-          prerelease: false
-          allowUpdates: true
-          artifacts: ${{ needs.build-macos.outputs.image_name }}
-          artifactContentType: application/dmg
-          replacesArtifacts: true
-          # Avoid overwriting a release that may have been manually edited
-          omitNameDuringUpdate: true
-          omitBodyDuringUpdate: true
-          omitDraftDuringUpdate: true
-          omitPrereleaseDuringUpdate: true
-
 
   # see https://github.com/AppImage/AppImageKit/wiki/Bundling-Python-apps
   build-appimage:

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -13,12 +13,7 @@
 # @date   July 2020
 
 name: Build
-on:
-  push:
-    tags:
-      # Not a regex! See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-      - 'v?[0-9]+.[0-9]+.[0-9]+'
-      - 'v?[0-9]+.[0-9]+.[0-9]+-[a-zA-Z0-9]+'
+on: [push, pull_request]
 
 jobs:
   setup:
@@ -32,6 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0 # necessary for `git describe`
       - uses: ./.github/actions/init-environment
         id: vars
       - name: Get firmware version matching manifest
@@ -180,6 +176,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0 # necessary for `git describe`
       - uses: ./.github/actions/init-environment
         id: vars
       - name: Install dependencies
@@ -294,6 +291,7 @@ jobs:
           Move-Item -Path target\AYABSetup.exe -Destination target\AYAB-${{ steps.vars.outputs.tag }}.exe
       - name: Upload asset
         uses: ncipollo/release-action@v1
+        if: steps.vars.outputs.do-release == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.vars.outputs.tag }}
@@ -334,6 +332,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0 # necessary for `git describe`
       - uses: ./.github/actions/init-environment
         id: vars
       - name: Install dependencies
@@ -463,6 +462,7 @@ jobs:
 
       - name: Attach disk image (before notarization) to release
         uses: ncipollo/release-action@v1
+        if: steps.vars.outputs.do-release == 'true'
         with:
           tag: ${{ steps.vars.outputs.tag }}
           # Default to draft and prerelease to let a human check the release before it goes live
@@ -569,7 +569,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          fetch-depth: 0
+          fetch-depth: 0 # necessary for `git describe`
       - uses: ./.github/actions/init-environment
         id: vars
       - name: Relocate
@@ -707,6 +707,7 @@ jobs:
           mv ayab-${{ steps.vars.outputs.tag }}-x86_64.AppImage AYAB-${{ steps.vars.outputs.tag }}-x86_64.AppImage
       - name: Upload asset
         uses: ncipollo/release-action@v1
+        if: steps.vars.outputs.do-release == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.vars.outputs.tag }}

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   build-windows:
-    name: Create and upload Windows release
+    name: Create and upload Windows build
     runs-on: windows-latest
     steps:
       - name: Checkout code
@@ -28,13 +28,16 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0 # necessary for `git describe`
+
       - uses: ./.github/actions/init-environment
         id: vars
+
       - name: Get firmware version matching manifest
         shell: bash
         working-directory: src/main/resources/base/ayab/firmware/
         run: |
-          curl -O ${{ steps.vars.outputs.firmware-url }}
+          curl --fail -O '${{ steps.vars.outputs.firmware-url }}'
+
       - name: Install dependencies
         shell: pwsh
         run: |
@@ -42,14 +45,17 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.build.txt
           python -m pip install -r windows-build\windows_build_requirements.txt
+
       - name: Convert UI and translation files
         run: |
           bash setup-environment.ps1
+
       - name: Remove unneeded files
         shell: bash
         run: |
           rm src/main/python/main/ayab/*_gui.ui
           rm src/main/python/main/ayab/ayab_logo_rc.qrc
+
       - name: Change line endings to CRLF
         shell: bash
         run: |
@@ -80,12 +86,14 @@ jobs:
       - name: Build app
         shell: pwsh
         run: python -m fbs freeze
+
       - name: Create installer
         shell: pwsh
         run: |
           python -m fbs installer
           Move-Item -Path target\AYABSetup.exe -Destination target\AYAB-${{ steps.vars.outputs.tag }}.exe
-      - name: Upload asset
+
+      - name: Attach installer to release
         uses: ncipollo/release-action@v1
         if: steps.vars.outputs.do-release == 'true'
         with:
@@ -104,13 +112,14 @@ jobs:
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitPrereleaseDuringUpdate: true
+
       - uses: actions/upload-artifact@v4
         with:
           name: AYAB-${{ steps.vars.outputs.tag }}.exe
           path: target/AYAB-${{ steps.vars.outputs.tag }}.exe
 
   build-macos:
-    name: Create and upload Mac OSX release
+    name: Create and upload Mac OSX build
     runs-on: macos-14
     env:
       APPLE_CERTIFICATE_NAME: ${{ secrets.APPLE_CERTIFICATE_NAME }}
@@ -121,13 +130,16 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0 # necessary for `git describe`
+
       - uses: ./.github/actions/init-environment
         id: vars
+
       - name: Get firmware version matching manifest
         shell: bash
         working-directory: src/main/resources/base/ayab/firmware/
         run: |
-          curl -O ${{ steps.vars.outputs.firmware-url }}
+          curl --fail -O '${{ steps.vars.outputs.firmware-url }}'
+
       - name: Install dependencies
         run: |
           mkdir tmp-wheel/
@@ -152,9 +164,11 @@ jobs:
           python -m pip install tmp-wheel/*.whl bitarray*.whl
 
           python -m pip install --no-binary charset_normalizer -r requirements.build.txt
+
       - name: Convert UI and translation files
         run: |
           bash setup-environment.ps1
+
       - name: Remove unneeded files
         run: |
           rm src/main/python/main/ayab/*_gui.ui
@@ -248,36 +262,45 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0 # necessary for `git describe`
+
       - uses: ./.github/actions/init-environment
         id: vars
+
       - name: Get firmware version matching manifest
         shell: bash
         working-directory: src/main/resources/base/ayab/firmware/
         run: |
-          curl -O ${{ steps.vars.outputs.firmware-url }}
+          curl --fail -O '${{ steps.vars.outputs.firmware-url }}'
+
       - name: Install Python modules
         run: |
           sudo apt-get install -y avrdude libasound2-dev
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
           python -m pip install -r requirements.build.txt
+
       - name: Convert UI and translation files
         run: |
           bash setup-environment.ps1
+
       - name: Relocate
         run: |
           mkdir git
           shopt -s extglob dotglob
           cp -r !(git) git
           shopt -u dotglob
+
       - name: Download AppImage of Python designed for manylinux
         run: wget -c https://github.com/niess/python-appimage/releases/download/python${{steps.vars.outputs.python-minor}}/${{steps.vars.outputs.python-appimage}}
+
       - name: Extract the AppImage
         run: |
           chmod +x ${{steps.vars.outputs.python-appimage}}
           ./${{steps.vars.outputs.python-appimage}} --appimage-extract
+
       - name: Move repo
         run: mv git/* squashfs-root
+
       - name: Install dependencies
         run: |
           cd squashfs-root
@@ -286,21 +309,25 @@ jobs:
           # hack to fix setup.py script with faulty include
           ./AppRun -m pip install --global-option=build_ext --global-option="-I$(pwd)/opt/${{steps.vars.outputs.python-minor}}/include/${{steps.vars.outputs.python-minor}}" simpleaudio
           ./AppRun -m pip install -r requirements.build.txt
+
       - name: Add AppDir subdirectories to PATH
         run: |
           echo "usr/bin" >> $GITHUB_PATH
           echo "opt/${{steps.vars.outputs.python-minor}}/bin" >> $GITHUB_PATH
+
       - name: Remove unneeded files
         run: |
           rm squashfs-root/src/main/python/main/ayab/*_gui.ui
           rm squashfs-root/src/main/python/main/ayab/ayab_logo_rc.qrc
           rm squashfs-root/src/main/python/main/ayab/engine/lowercase_e_rc.qrc
           rm squashfs-root/src/main/python/main/ayab/engine/lowercase_e_reversed_rc.qrc
+
       - name: Replace AppRun
         run: |
           cd squashfs-root
           rm AppRun
           cp linux-build/appimage/AppRun .
+
       - name: Add icon
         run: |
           cd squashfs-root
@@ -309,6 +336,7 @@ jobs:
           cp linux-build/appimage/ayab.png ayab.png
           mkdir -p usr/share/icons/hicolor/128x128/apps/
           cp ayab.png usr/share/icons/hicolor/128x128/apps/
+
       - name: Create desktop file
         run: |
           cd squashfs-root
@@ -317,12 +345,14 @@ jobs:
           rm -f usr/share/applications/*.desktop
           cp linux-build/appimage/com.ayab_knitting.ayab.desktop com.ayab_knitting.ayab.desktop
           cp com.ayab_knitting.ayab.desktop usr/share/applications/com.ayab_knitting.ayab.desktop
+
       - name: Add metadata
         run: |
           cd squashfs-root
           mkdir -p usr/share/metainfo/
           rm -f usr/share/metainfo/*.appdata.xml
           cp linux-build/appimage/ayab.appdata.xml usr/share/metainfo/
+
       - name: Convert to AppImage
         run: |
           wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases/expanded_assets/continuous -O - | grep appimagetool-.*-x86_64.AppImage | head -n 1 | cut -d '"' -f 2)
@@ -332,7 +362,8 @@ jobs:
           VERSION=${{steps.vars.outputs.tag}} ./appimagetool-*-x86_64.AppImage squashfs-root/
           sudo apt remove appstream
           mv ayab-${{ steps.vars.outputs.tag }}-x86_64.AppImage AYAB-${{ steps.vars.outputs.tag }}-x86_64.AppImage
-      - name: Upload asset
+
+      - name: Attach AppImage to release
         uses: ncipollo/release-action@v1
         if: steps.vars.outputs.do-release == 'true'
         with:
@@ -351,6 +382,7 @@ jobs:
           omitBodyDuringUpdate: true
           omitDraftDuringUpdate: true
           omitPrereleaseDuringUpdate: true
+
       - uses: actions/upload-artifact@v4
         with:
           name: AYAB-${{ steps.vars.outputs.tag }}-x86_64.AppImage

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -15,6 +15,9 @@
 name: Build
 on: [push, pull_request]
 
+env:
+  PYTHON_VERSION: 3.11.9
+
 jobs:
   deploy:
     name: Create and deploy source code documentation
@@ -42,9 +45,6 @@ jobs:
   build-windows:
     name: Create and upload Windows release
     runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: [3.11.9]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -139,9 +139,6 @@ jobs:
       tag: ${{ steps.vars.outputs.tag }}
       submission_id: ${{ steps.notarize.outputs.submission_id }}
       image_name: ${{ steps.diskimage.outputs.name }}
-    strategy:
-      matrix:
-        python-version: [3.11.9]
     env:
       APPLE_CERTIFICATE_NAME: ${{ secrets.APPLE_CERTIFICATE_NAME }}
       APPLE_STORE_CONNECT_KEY_ID: ${{ secrets.APPLE_STORE_CONNECT_KEY_ID }}
@@ -330,10 +327,9 @@ jobs:
   build-appimage:
     name: Create and upload Linux AppImage release
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        # Using Python 3.11.11 specifically for Linux builds due to python-appimage availability
-        python-version: [3.11.11]
+    env:
+      # Using Python 3.11.11 specifically for Linux builds due to python-appimage availability
+      PYTHON_VERSION: 3.11.11
     steps:
       - name: Checkout repo into AppDir
         uses: actions/checkout@v4

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -254,8 +254,8 @@ jobs:
     name: Create and upload Linux AppImage release
     runs-on: ubuntu-22.04
     env:
-      # Using Python 3.11.11 specifically for Linux builds due to python-appimage availability
-      PYTHON_VERSION: 3.11.11
+      # Using a specific Python version for Linux builds due to python-appimage availability
+      PYTHON_VERSION: 3.11.12
     steps:
       - name: Checkout repo into AppDir
         uses: actions/checkout@v4

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -19,29 +19,6 @@ env:
   PYTHON_VERSION: 3.11.9
 
 jobs:
-  deploy:
-    name: Create and deploy source code documentation
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Install dependencies for doxygen
-        run: |
-          sudo apt-get install doxygen graphviz -y
-      - name: Create .nojekyll so that filenames with underscores work on Github Pages
-        run: |
-          mkdir -p docs/html
-          touch docs/html/.nojekyll
-      - name: Deploy to pages
-        uses: DenverCoder1/doxygen-github-pages-action@v1.3.1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
-          folder: docs/html
-          config_file: Doxyfile
-
   build-windows:
     name: Create and upload Windows release
     runs-on: windows-latest

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,28 @@
+name: Deploy pages
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dependencies for doxygen
+        run: |
+          sudo apt-get install doxygen graphviz -y
+      - name: Create .nojekyll so that filenames with underscores work on Github Pages
+        run: |
+          mkdir -p docs/html
+          touch docs/html/.nojekyll
+      - name: Deploy to pages
+        uses: DenverCoder1/doxygen-github-pages-action@v1.3.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: docs/html
+          config_file: Doxyfile

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -5,18 +5,18 @@ name: Python Tests
 
 on: [push, pull_request]
 
+env:
+  PYTHON_VERSION: 3.11.9
+
 jobs:
   run-pytest:
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        python-version: [3.11]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Problem

Fixes #774 .

## Proposed solution

This PR changes the build workflow to not use any caching. Instead the required file generation is done separately on each platform.

This has the side benefit of simplifying the build workflow. And the duration of the builds without caching is very similar to the current duration, 5-6 minutes.

Additionally, the trigger for running the build workflow was changed so that it runs on all code pushes (local branches and pull requests). This should reduce the need for manually triggering test releases. As an example, this PR itself triggers the build workflow on its branch. Note that signing and notarization are automatically disabled for builds done from PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automated deployment of documentation now publishes the latest reference guides.
  - Enhanced firmware release detection improves the accuracy and reliability of firmware downloads.
  - New output variables for firmware version and release detection added to the environment setup.

- **Chores**
  - Streamlined build processes for Windows, macOS, and Linux ensure more efficient release generation.
  - Simplified Python setup in testing workflows boosts consistency across releases.
  - New workflow for continuous deployment of documentation to GitHub Pages introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->