### PR TITLE
Bump Python to 3.11.13 for Linux build

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -251,7 +251,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       # Using a specific Python version for Linux builds due to python-appimage availability
-      PYTHON_VERSION: 3.11.12
+      PYTHON_VERSION: 3.11.13
     steps:
       - name: Checkout repo into AppDir
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #721 (again), because `python-appimage` removed the 3.11.12 image we were using. See [niess/python-appimage#88](https://redirect.github.com/niess/python-appimage/issues/88) for potential workarounds, but for now I'm just bumping the version to unblock the build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Linux AppImage build process to use Python 3.11.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->