### PR TITLE
Pin the Windows runner image to windows-2022

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   build-windows:
     name: Create and upload Windows build
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The `windows-latest` GitHub Actions runner image alias just [started to point to `windows-2025` images](https://github.com/actions/runner-images/issues/12677) and those [no longer contain the NSIS executable](https://github.com/actions/runner-images/issues/11754) required by `fbs`.

This causes the Windows build to [fail](https://github.com/AllYarnsAreBeautiful/ayab-desktop/actions/runs/17588662352/job/49963470581).

## Proposed solution

Explicitly request a `windows-2022` image for the build. I briefly attempted to install NSIS on the `windows-2025` image but gave up after it turned out that `choco install nsis` was not sufficient (that package does not add the proper binaries to the PATH…). Based on GitHub's policy and the Windows release schedule, it seems the `windows-2022` image should remain available until  at least 2028.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows build environment in CI to use Windows Server 2022.
  * Aligns Windows builds with a consistent, modern runner across the pipeline.
  * Improves build reliability and predictability for Windows targets.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->