### PR TITLE
Change default log level to INFO

### DIFF
--- a/src/main/python/main/ayab/engine/communication.py
+++ b/src/main/python/main/ayab/engine/communication.py
@@ -72,8 +72,8 @@ class Communication(object):
     def __init__(self, serial: Optional[serial.Serial | WebsocketSerial] = None):
         """Create an AyabCommunication object,
         with an optional serial communication object."""
-        logging.basicConfig(level=logging.DEBUG)
         self.logger = logging.getLogger(type(self).__name__)
+        self.logger.setLevel(logging.DEBUG)
         self.__ser = serial
         self.__driver = sliplib.Driver()
         self.rx_msg_list: list[bytes] = list()

--- a/src/main/python/main/main.py
+++ b/src/main/python/main/main.py
@@ -53,7 +53,7 @@ class AppContext(ApplicationContext):  # type: ignore # 1. Subclass ApplicationC
         logfile = path.join(self.userdata_path, "ayab_log.txt")
         logging.basicConfig(
             filename=logfile,
-            level=logging.DEBUG,
+            level=logging.INFO,
             format="%(asctime)s %(name)-8s %(levelname)-8s %(message)s",
             datefmt="%y-%m-%d %H:%M:%S",
         )


### PR DESCRIPTION
Remove default logging.basicConfig in Communication class init; it has no effect and should be set once in main.py anyway.

The DEBUG log level should not be set in the root log as it may be used as the default for other modules and thus unnecessarily increase verbosity.

I added a setlevel(DEBUG) to the Communication's logger to keep the intended DEBUG level there but this should probably be set to INFO as well (or removed, added when required/while debugging).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Switched to per-instance logging to isolate component logs and avoid altering global logging behavior.
- Chores
  - Lowered default file log level from DEBUG to INFO to reduce noisy entries while keeping formats and timestamps, yielding cleaner logs for routine monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->