### PR TITLE
Adapt retry logic for communication with firmware

### DIFF
--- a/src/main/python/main/ayab/engine/engine_fsm.py
+++ b/src/main/python/main/ayab/engine/engine_fsm.py
@@ -121,6 +121,7 @@ class StateMachine(QStateMachine):
                 control.api_version = param
                 control.state = State.INIT
                 control.logger.debug("State INIT")
+                control.com.req_init_API6(control.machine)
                 return Output.NONE
             else:
                 control.logger.error(
@@ -153,7 +154,6 @@ class StateMachine(QStateMachine):
                 control.logger.error("Error initializing firmware: " + str(param))
                 return Output.ERROR_INITIALIZING_FIRMWARE
         # else
-        StateMachine.retry(control.com.req_init_API6, (control.machine,))
         return Output.INITIALIZING_FIRMWARE
 
     @staticmethod


### PR DESCRIPTION
This is to avoid latency issues with Wifi connections where delay is often more than 100m, e.g. from discord discussions

```
gjh@fedora:~$ ping ayab.local
PING ayab.local (192.168.0.129) 56(84) bytes of data.
64 bytes from 192.168.0.129: icmp_seq=1 ttl=64 time=344 ms
64 bytes from 192.168.0.129: icmp_seq=2 ttl=64 time=558 ms
64 bytes from 192.168.0.129: icmp_seq=3 ttl=64 time=181 ms
64 bytes from 192.168.0.129: icmp_seq=4 ttl=64 time=400 ms
64 bytes from 192.168.0.129: icmp_seq=5 ttl=64 time=632 ms
64 bytes from 192.168.0.129: icmp_seq=6 ttl=64 time=241 ms
64 bytes from 192.168.0.129: icmp_seq=7 ttl=64 time=468 ms
64 bytes from 192.168.0.129: icmp_seq=8 ttl=64 time=86.6 ms
64 bytes from 192.168.0.129: icmp_seq=9 ttl=64 time=523 ms
64 bytes from 192.168.0.129: icmp_seq=10 ttl=64 time=546 ms
64 bytes from 192.168.0.129: icmp_seq=11 ttl=64 time=149 ms
64 bytes from 192.168.0.129: icmp_seq=12 ttl=64 time=377 ms
64 bytes from 192.168.0.129: icmp_seq=13 ttl=64 time=617 ms
64 bytes from 192.168.0.129: icmp_seq=14 ttl=64 time=217 ms
64 bytes from 192.168.0.129: icmp_seq=15 ttl=64 time=455 ms
64 bytes from 192.168.0.129: icmp_seq=16 ttl=64 time=58.7 ms
64 bytes from 192.168.0.129: icmp_seq=17 ttl=64 time=286 ms
64 bytes from 192.168.0.129: icmp_seq=18 ttl=64 time=515 ms
64 bytes from 192.168.0.129: icmp_seq=19 ttl=64 time=126 ms
64 bytes from 192.168.0.129: icmp_seq=20 ttl=64 time=364 ms
64 bytes from 192.168.0.129: icmp_seq=21 ttl=64 time=792 ms
64 bytes from 192.168.0.129: icmp_seq=22 ttl=64 time=195 ms
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Initialization now starts immediately after a successful API6 token validation.
  * Removed automatic scheduling of a retry during API6 initialization; the flow now enters "initializing firmware" without queuing a retry.
  * Increased the default retry interval from 0.1s to 1.0s (users may notice slower, less frequent automatic retries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->