### PR TITLE
Add support for continuous reporting

### DIFF
--- a/src/main/python/main/ayab/engine/control.py
+++ b/src/main/python/main/ayab/engine/control.py
@@ -39,6 +39,8 @@ from .status import Carriage, Direction, StatusTab
 from .pattern import Pattern
 from ..preferences import Preferences
 
+import struct
+
 
 class Control(SignalSender):
     """
@@ -168,10 +170,40 @@ class Control(SignalSender):
             self.__log_cnfInfo(msg)
         elif token == Token.indState:
             self.status.parse_device_state_API6(param, msg)
+            self.__log_indState(msg)
         elif token == Token.testRes:
             if len(msg) > 0:
                 self.emit_hw_test_writer(msg[1:].decode())
         return token, param
+
+    def __log_indState(self, msg: bytes) -> None:
+        directionMap = {0x00: "Left ", 0x01: "Right", 0xFF: "?"}
+        machineSideMap = {0x00: "? ", 0x01: "Left", 2: "Right"}
+        beltShiftMap = {0x00: "?", 0x01: "Regular", 0x02: "Shifted"}
+        carriageMap = {0x00: "K", 0x01: "L", 0x02: "G", 0x03: "K270", 0xFF: "None"}
+
+        error = msg[1]
+        state = msg[2]
+        hallLeft = struct.unpack(">H", msg[3:5])[0]
+        hallRight = struct.unpack(">H", msg[5:7])[0]
+        carriage = carriageMap[msg[7]]
+        position = msg[8]
+        direction = directionMap[msg[9]]
+
+        try:  # AyabAsync supplies additional parameters
+            hallActive = machineSideMap[msg[10]]
+            beltShift = beltShiftMap[msg[11]]
+            self.logger.info(
+                f"IndState: {error:1d} {state:1d} {position:3d}"
+                f" {carriage:5s} ({beltShift:11s},{direction:5s})"
+                f" Hall:{hallActive:5s} ({hallLeft:5d}, {hallRight:5d})"
+            )
+        except IndexError:
+            self.logger.info(
+                f"IndState: {error:1d} {state:1d} {position:3d}"
+                f" {carriage:5s} ({direction:5s})"
+                f" Hall:({hallLeft:5d}, {hallRight:5d})"
+            )
 
     def __log_cnfInfo(self, msg: bytes) -> None:
         api = msg[1]

--- a/src/main/python/main/ayab/engine/control.py
+++ b/src/main/python/main/ayab/engine/control.py
@@ -186,13 +186,13 @@ class Control(SignalSender):
         state = msg[2]
         hallLeft = struct.unpack(">H", msg[3:5])[0]
         hallRight = struct.unpack(">H", msg[5:7])[0]
-        carriage = carriageMap[msg[7]]
+        carriage = carriageMap.get(msg[7], f"0x{msg[7]:02x}?")
         position = msg[8]
-        direction = directionMap[msg[9]]
+        direction = directionMap.get(msg[9], f"0x{msg[9]:02x}?")
 
         try:  # AyabAsync supplies additional parameters
-            hallActive = machineSideMap[msg[10]]
-            beltShift = beltShiftMap[msg[11]]
+            hallActive = machineSideMap.get(msg[10], f"0x{msg[10]:02x}?")
+            beltShift = beltShiftMap.get(msg[11], f"0x{msg[11]:02x}?")
             self.logger.info(
                 f"IndState: {error:1d} {state:1d} {position:3d}"
                 f" {carriage:5s} ({beltShift:11s},{direction:5s})"

--- a/src/main/python/main/ayab/engine/engine_fsm.py
+++ b/src/main/python/main/ayab/engine/engine_fsm.py
@@ -31,6 +31,7 @@ from .hw_test_communication_mock import HardwareTestCommunicationMock
 from .output import Output
 from typing import TYPE_CHECKING, Callable, Any
 
+import os
 import time
 
 if TYPE_CHECKING:
@@ -171,7 +172,7 @@ class StateMachine(QStateMachine):
                 control.com.req_start_API6(
                     control.pattern.knit_start_needle,
                     control.pattern.knit_end_needle - 1,
-                    control.continuous_reporting,
+                    True if os.getenv("AYAB_DEBUG") else control.continuous_reporting,
                     control.prefs.value("disable_hardware_beep"),
                 )
                 control.state = State.CONFIRM_START


### PR DESCRIPTION
Log the contents of the indState message to the console Continuous reporting remains disabled by default and can be enabled by setting the AYAB_DEBUG environment variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More detailed, human-readable status logs for device state with structured output and graceful fallback when some fields are missing, improving troubleshooting and operator visibility.
  * Debug mode: set AYAB_DEBUG to force continuous reporting during sessions; default behavior unchanged otherwise.

* **Refactor**
  * Minor internal reorganization to integrate the enhanced logging path without affecting other functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->