### PR TITLE
Implement recent files feature for desktop application

### DIFF
--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -257,7 +257,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       # Using a specific Python version for Linux builds due to python-appimage availability
-      PYTHON_VERSION: 3.11.13
+      PYTHON_VERSION: 3.11.14
     steps:
       - name: Checkout repo into AppDir
         uses: actions/checkout@v4

--- a/.github/workflows/build-multi-os.yml
+++ b/.github/workflows/build-multi-os.yml
@@ -304,7 +304,8 @@ jobs:
           sudo apt-get install -y avrdude libasound2-dev
           ./AppRun -m pip install --upgrade pip
           # hack to fix setup.py script with faulty include
-          ./AppRun -m pip install --global-option=build_ext --global-option="-I$(pwd)/opt/${{steps.vars.outputs.python-minor}}/include/${{steps.vars.outputs.python-minor}}" simpleaudio
+          #./AppRun -m pip install --global-option=build_ext --global-option="-I$(pwd)/opt/${{steps.vars.outputs.python-minor}}/include/${{steps.vars.outputs.python-minor}}" simpleaudio
+          ./AppRun -m pip install --config-settings="--build-option=build_ext" --config-settings="--build-option=-I$(pwd)/opt/${{steps.vars.outputs.python-minor}}/include/${{steps.vars.outputs.python-minor}}" simpleaudio
           ./AppRun -m pip install -r requirements.build.txt
 
       - name: Add AppDir subdirectories to PATH

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -1,7 +1,7 @@
 setuptools==75.8.0
 fbs @ git+https://github.com/AllYarnsAreBeautiful/fbs@1.2.1-pyqt6
 PySide6==6.6.2
-PyInstaller==6.4.0
+PyInstaller==6.21.0
 Pillow==10
 pyserial==3.5
 sliplib==0.6.2

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -1,5 +1,5 @@
 setuptools==75.8.0
-fbs @ git+https://github.com/dmitrys99/fbs@1.2.1-pyqt6-solo
+fbs @ git+https://github.com/dmitrys99/fbs@ayab-fork
 PySide6==6.6.2
 PyInstaller==6.21.0
 Pillow==10

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -1,5 +1,5 @@
 setuptools==75.8.0
-fbs @ git+https://github.com/AllYarnsAreBeautiful/fbs@1.2.1-pyqt6
+fbs @ git+https://github.com/dmitrys99/fbs@1.2.1-pyqt6-solo
 PySide6==6.6.2
 PyInstaller==6.21.0
 Pillow==10

--- a/src/main/python/main/ayab/engine/control.py
+++ b/src/main/python/main/ayab/engine/control.py
@@ -213,6 +213,7 @@ class Control(SignalSender):
         # get data for next line of knitting
         color, row_index, blank_line, last_line = self.mode_func(self, line_number)
         bits = self.select_needles_API6(color, row_index, blank_line)
+        self.logger.debug("bits (select_needles_API6): " + bits.to01())
 
         # Send line to machine
         # Note that we never set the "final line" flag here, because

--- a/src/main/python/main/ayab/image.py
+++ b/src/main/python/main/ayab/image.py
@@ -79,6 +79,7 @@ class AyabImage(SignalSender):
             self.__load(str(selected_file))
 
     def load(self, filename: str) -> None:
+        """Public wrapper for image loading functionality"""
         self.__load(filename)
 
     def __load(self, filename: str) -> None:

--- a/src/main/python/main/ayab/image.py
+++ b/src/main/python/main/ayab/image.py
@@ -80,6 +80,8 @@ class AyabImage(SignalSender):
 
     def load(self, filename: str) -> None:
         """Public wrapper for image loading functionality"""
+        self.filename = filename
+        self.filename_input.setText(filename)
         self.__load(filename)
 
     def __load(self, filename: str) -> None:

--- a/src/main/python/main/ayab/image.py
+++ b/src/main/python/main/ayab/image.py
@@ -78,6 +78,9 @@ class AyabImage(SignalSender):
             self.filename_input.setText(selected_file)
             self.__load(str(selected_file))
 
+    def load(self, filename: str) -> None:
+        self.__load(filename)
+
     def __load(self, filename: str) -> None:
         """Load an image into the graphics scene."""
         # TODO Check maximum width of image
@@ -99,6 +102,11 @@ class AyabImage(SignalSender):
             # self.emit_statusbar_updater(filename, True)
             self.__parent.scene.row_progress = 0
             self.__parent.engine.config.refresh()
+
+            # After successul file open add file to recents
+            self.__parent.prefs.addRecent(filename)
+            # and update menu
+            self.__parent.menu.showRecents()
 
     def __open(self, filename: str) -> None:
         # check for files that need conversion

--- a/src/main/python/main/ayab/menu.py
+++ b/src/main/python/main/ayab/menu.py
@@ -21,9 +21,10 @@
 from __future__ import annotations
 from PySide6.QtCore import QOperatingSystemVersion
 from PySide6.QtWidgets import QMenuBar
+from PySide6.QtGui import QAction
 
 from .menu_gui import Ui_MenuBar
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from .ayab import GuiMain
@@ -38,7 +39,7 @@ class Menu(QMenuBar):
 
     def __init__(self, parent: GuiMain):
         super().__init__(parent)
-
+        self.__parent = parent
         # Use native menubar on macOS, not elsewhere (i.e. Linux)
         if (
             QOperatingSystemVersion.currentType()
@@ -60,10 +61,10 @@ class Menu(QMenuBar):
         if not hasattr(self, "recents"):
             self.recents = [
                 getattr(self.ui, "action_recent_" + str(x))
-                for x in range(self.parent().prefs.MAX_RECENT_COUNT)
+                for x in range(self.__parent.prefs.MAX_RECENT_COUNT)
             ]
             for action in self.recents:
-                action.triggered.connect(self.load_recent)
+                action.triggered.connect(self.loadRecent)
 
         # Set up recent files menus
         self.showRecents()
@@ -82,8 +83,8 @@ class Menu(QMenuBar):
         # Get file names from recents list
         # and make items visible if there are files available.
         i = 0
-        while i < self.parent().prefs.MAX_RECENT_COUNT and i < len(self.parent().prefs.recentFiles):
-            self.recents[i].setText(self.parent().prefs.recentFiles[i])
+        while i < self.__parent.prefs.MAX_RECENT_COUNT and i < len(self.__parent.prefs.recentFiles):
+            self.recents[i].setText(self.__parent.prefs.recentFiles[i])
             self.recents[i].setVisible(True)
             i += 1
 
@@ -93,10 +94,10 @@ class Menu(QMenuBar):
 
     # Function is a recent menu click handler
     # Load image from file
-    def load_recent(self, _) -> None:
+    def loadRecent(self, _: QAction) -> None:
         """Recent menu action click handler"""
-        filename = self.sender().text()
-        self.parent().scene.ayabimage.load(filename)
+        filename = cast(QAction, self.sender()).text()
+        self.__parent.scene.ayabimage.load(filename)
 
     def depopulate(self) -> None:
         try:

--- a/src/main/python/main/ayab/menu.py
+++ b/src/main/python/main/ayab/menu.py
@@ -51,6 +51,7 @@ class Menu(QMenuBar):
         self.setup()
 
     def setup(self) -> None:
+        """Initial menu setup"""
         self.addAction(self.ui.menu_tools.menuAction())
         self.addAction(self.ui.menu_preferences.menuAction())
         self.addAction(self.ui.menu_help.menuAction())

--- a/src/main/python/main/ayab/menu.py
+++ b/src/main/python/main/ayab/menu.py
@@ -56,22 +56,25 @@ class Menu(QMenuBar):
         self.addAction(self.ui.menu_preferences.menuAction())
         self.addAction(self.ui.menu_help.menuAction())
 
+        # Wire recent file actions once (guard prevents re-wiring on repopulate())
+        if not hasattr(self, "recents"):
+            self.recents = [
+                getattr(self.ui, "action_recent_" + str(x))
+                for x in range(self.parent().prefs.MAX_RECENT_COUNT)
+            ]
+            for action in self.recents:
+                action.triggered.connect(self.load_recent)
+
         # Set up recent files menus
         self.showRecents()
 
     # Show recent files menus
     def showRecents(self) -> None:
         """Update recent files menu"""
-        self.recents = []
-
-        # Get recents actions from UI
-        for x in range(self.parent().prefs.MAX_RECENT_COUNT):
-            self.recents.append(self.ui.__dict__["action_recent_" + str(x)])
 
         # Set recents invisible
-        for x in range(self.parent().prefs.MAX_RECENT_COUNT):
-            self.recents[x].setVisible(False)
-            self.recents[x].triggered.connect(self.load_recent)
+        for action in self.recents:
+            action.setVisible(False)
 
         # Set recents menu invisible as well
         self.ui.menu_recent_files.menuAction().setVisible(False)

--- a/src/main/python/main/ayab/menu.py
+++ b/src/main/python/main/ayab/menu.py
@@ -93,7 +93,7 @@ class Menu(QMenuBar):
 
     # Function is a recent menu click handler
     # Load image from file
-    def load_recent(self, e) -> None:
+    def load_recent(self, _) -> None:
         """Recent menu action click handler"""
         filename = self.sender().text()
         self.parent().scene.ayabimage.load(filename)

--- a/src/main/python/main/ayab/menu.py
+++ b/src/main/python/main/ayab/menu.py
@@ -28,7 +28,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .ayab import GuiMain
 
-
 class Menu(QMenuBar):
     """
     Menu bar object and associated methods.
@@ -55,6 +54,45 @@ class Menu(QMenuBar):
         self.addAction(self.ui.menu_tools.menuAction())
         self.addAction(self.ui.menu_preferences.menuAction())
         self.addAction(self.ui.menu_help.menuAction())
+
+        # Set up recent files menus
+        self.showRecents()
+
+    # Show recent files menus
+    def showRecents(self) -> None:
+        """Update recent files menu"""
+        self.recents = []
+
+        # Get recents actions from UI
+        for x in range(self.parent().prefs.MAX_RECENT_COUNT):
+            self.recents.append(self.ui.__dict__["action_recent_" + str(x)])
+
+        # Set recents invisible
+        for x in range(self.parent().prefs.MAX_RECENT_COUNT):
+            self.recents[x].setVisible(False)
+            self.recents[x].triggered.connect(self.load_recent)
+
+        # Set recents menu invisible as well
+        self.ui.menu_recent_files.menuAction().setVisible(False)
+
+        # Get file names from recents list
+        # and make items visible if there are files available.
+        i = 0
+        while i < self.parent().prefs.MAX_RECENT_COUNT and i < len(self.parent().prefs.recentFiles):
+            self.recents[i].setText(self.parent().prefs.recentFiles[i])
+            self.recents[i].setVisible(True)
+            i += 1
+
+        # Set visible toplevel menu item if there are recent files available
+        if i > 0:
+            self.ui.menu_recent_files.menuAction().setVisible(True)
+
+    # Function is a recent menu click handler
+    # Load image from file
+    def load_recent(self, e) -> None:
+        """Recent menu action click handler"""
+        filename = self.sender().text()
+        self.parent().scene.ayabimage.load(filename)
 
     def depopulate(self) -> None:
         try:

--- a/src/main/python/main/ayab/menu_gui.ui
+++ b/src/main/python/main/ayab/menu_gui.ui
@@ -7,7 +7,19 @@
     <string>File</string>
    </property>
    <addaction name="action_open_image_file"/>
+   <addaction name="menu_recent_files"/>
+   <addaction name="separator"/>
    <addaction name="action_quit"/>
+  </widget>
+  <widget class="QMenu" name="menu_recent_files">
+   <property name="title">
+    <string>Recent Files</string>
+   </property>
+   <addaction name="action_recent_0"/>
+   <addaction name="action_recent_1"/>
+   <addaction name="action_recent_2"/>
+   <addaction name="action_recent_3"/>
+   <addaction name="action_recent_4"/>
   </widget>
   <widget class="QMenu" name="menu_help">
    <property name="title">
@@ -58,6 +70,33 @@
     <string notr="true">Ctrl+O</string>
    </property>
   </action>
+
+  <action name="action_recent_0">
+   <property name="text">
+    <string>recent0</string>
+   </property>
+  </action>
+  <action name="action_recent_1">
+   <property name="text">
+    <string>recent1</string>
+   </property>
+  </action>
+  <action name="action_recent_2">
+   <property name="text">
+    <string>recent2</string>
+   </property>
+  </action>
+  <action name="action_recent_3">
+   <property name="text">
+    <string>recent3</string>
+   </property>
+  </action>
+  <action name="action_recent_4">
+   <property name="text">
+    <string>recent4</string>
+   </property>
+  </action>
+
   <action name="action_quit">
    <property name="text">
     <string>Quit</string>

--- a/src/main/python/main/ayab/preferences.py
+++ b/src/main/python/main/ayab/preferences.py
@@ -141,7 +141,7 @@ class Preferences(SignalSender):
         self.settings.setFallbacksEnabled(False)
 
         """Recent files list"""
-        self.recentFiles = []
+        self.recentFiles: list[str] = []
         self.refresh()
 
     def refresh(self) -> None:
@@ -153,8 +153,8 @@ class Preferences(SignalSender):
         # and check if files are still available
         for i in range(self.MAX_RECENT_COUNT):
             filename = self.settings.value("Recent/" + str(i))
-            if filename is not None and os.path.exists(filename) and (filename not in self.recentFiles):
-                self.recentFiles.append(filename)
+            if filename is not None and os.path.exists(str(filename)) and (filename not in self.recentFiles):
+                self.recentFiles.append(str(filename))
 
         # Remove Recent section since it is possible
         # there are no available files
@@ -179,10 +179,10 @@ class Preferences(SignalSender):
         self.settings.remove("Recent")
 
     # Add file to recents, used during usual open from file.
-    def addRecent(self, fileName) -> None:
+    def addRecent(self, filename: str) -> None:
         """Add fileName to recent list if it is not already there"""
-        if not fileName in self.recentFiles:
-            self.recentFiles.insert(0, fileName)
+        if filename not in self.recentFiles:
+            self.recentFiles.insert(0, filename)
             self.refresh()
 
     @overload
@@ -258,6 +258,7 @@ class PrefsDialog(QDialog):
         self.__ui = Ui_Prefs()
         self.__ui.setupUi(self)
         self.__form = QFormLayout(self.__ui.prefs_group)
+        self.__parent = parent
 
         # add form items
         self.__widget = {}
@@ -300,7 +301,7 @@ class PrefsDialog(QDialog):
         self.__refresh_form()
 
         # Update recents menu after reset
-        self.parent().menu.showRecents()
+        self.__parent.menu.showRecents()
 
 
 class PrefsBoolWidget(QCheckBox):

--- a/src/main/python/main/ayab/preferences.py
+++ b/src/main/python/main/ayab/preferences.py
@@ -133,15 +133,15 @@ class Preferences(SignalSender):
     """How many recent files can be added to menu."""
     MAX_RECENT_COUNT = 5
 
-    """Recent files list"""
-    recentFiles = []
-
     def __init__(self, parent: GuiMain):
         super().__init__(parent.signal_receiver)
         self.parent = parent
         self.languages = Language(self.parent.app_context)
         self.settings: QSettings = QSettings()
         self.settings.setFallbacksEnabled(False)
+
+        """Recent files list"""
+        self.recentFiles = []
         self.refresh()
 
     def refresh(self) -> None:
@@ -153,7 +153,7 @@ class Preferences(SignalSender):
         # and check if files are still available
         for i in range(self.MAX_RECENT_COUNT):
             filename = self.settings.value("Recent/" + str(i))
-            if filename != None and os.path.exists(filename) and not (filename in self.recentFiles):
+            if filename is not None and os.path.exists(filename) and (filename not in self.recentFiles):
                 self.recentFiles.append(filename)
 
         # Remove Recent section since it is possible
@@ -295,8 +295,12 @@ class PrefsDialog(QDialog):
             widget.refresh()
 
     def __reset_and_refresh(self) -> None:
+        """Reset preferences and refresh UI accordingly"""
         self.__prefs.reset()
         self.__refresh_form()
+
+        # Update recents menu after reset
+        self.parent().menu.showRecents()
 
 
 class PrefsBoolWidget(QCheckBox):

--- a/src/main/python/main/ayab/preferences.py
+++ b/src/main/python/main/ayab/preferences.py
@@ -56,11 +56,12 @@ from typing import (
     overload,
 )
 
+import os
+
 if TYPE_CHECKING:
     from .ayab import GuiMain
 
 T = TypeVar("T")
-
 
 def str2bool(qvariant: str | bool) -> bool:
     if type(qvariant) is str:
@@ -129,6 +130,12 @@ class Preferences(SignalSender):
         "lower_display_stitch_width": int,
     }
 
+    """How many recent files can be added to menu."""
+    MAX_RECENT_COUNT = 5
+
+    """Recent files list"""
+    recentFiles = []
+
     def __init__(self, parent: GuiMain):
         super().__init__(parent.signal_receiver)
         self.parent = parent
@@ -138,8 +145,26 @@ class Preferences(SignalSender):
         self.refresh()
 
     def refresh(self) -> None:
+        """Sync variables and recent files list with saved configuration"""
         for var in self.variables.keys():
             self.settings.setValue(var, self.value(cast(PreferencesDictKeys, var)))
+
+        # Read recents from configuration
+        # and check if files are still available
+        for i in range(self.MAX_RECENT_COUNT):
+            filename = self.settings.value("Recent/" + str(i))
+            if filename != None and os.path.exists(filename) and not (filename in self.recentFiles):
+                self.recentFiles.append(filename)
+
+        # Remove Recent section since it is possible
+        # there are no available files
+        self.settings.remove("Recent")
+
+        # Save recents back to configuration
+        i = 0
+        while i < self.MAX_RECENT_COUNT and i < len(self.recentFiles):
+            self.settings.setValue("Recent/" + str(i), self.recentFiles[i])
+            i += 1
 
     def reset(self) -> None:
         """Reset all the fields except language"""
@@ -148,6 +173,17 @@ class Preferences(SignalSender):
                 self.settings.setValue(
                     var, self.default_value(cast(PreferencesDictKeys, var))
                 )
+
+        # Reset recent files list and remove section
+        self.recentFiles = []
+        self.settings.remove("Recent")
+
+    # Add file to recents, used during usual open from file.
+    def addRecent(self, fileName) -> None:
+        """Add fileName to recent list if it is not already there"""
+        if not fileName in self.recentFiles:
+            self.recentFiles.insert(0, fileName)
+            self.refresh()
 
     @overload
     def value(self, var: PreferencesDictBoolKeys) -> bool: ...

--- a/src/main/resources/base/ayab/translations/ayab-translation-master.tsv
+++ b/src/main/resources/base/ayab/translations/ayab-translation-master.tsv
@@ -61,6 +61,7 @@ MenuBar	Repeat	Repeat	Wiederholen	Endurtaka	Ripeti	Повторить	Повто
 MenuBar	Reflect	Reflect	Spiegeln	Endurspegla	Rifletti	Отразить	Відобразити	Refléter	Reflejar	반영	反映する	镜像
 MenuBar	Horizontal Flip	Horizontal Flip	Horizontal spiegeln	Snúa lárétt	Inverti orizzontale	Отражение по горизонтали	Відобразити по горизонталі	Retourner horizontal	Volteo horizontal	수평 뒤집기	水平反転	水平翻转
 MenuBar	Vertical Flip	Vertical Flip	Vertikal spiegeln	Snúa lóðrétt	Inverti verticale	Отражение по вертикали	Відобразити по вертикалі	Retourner vertical	Volteo vertical	수직 뒤집기	垂直反転	垂直翻转
+MenuBar	Recent Files	Recent Files				Последние файлы						
 MenuBar	Rotate Left	Rotate Left	Links drehen	Snúa til vinstri	Ruota a sinistra	Поворот влево	Обертати ліворуч	Rotation à gauche	Girar a la izquierda	왼쪽으로 돌리기	左に回転	左转
 MenuBar	Rotate Right	Rotate Right	Rechts drehen	Snúa til hægri	Ruota a destra	Поворот вправо	Обертати праворуч	Rotation à droite	Girar a la derecha	오른쪽으로 돌리기	右に回転	右转
 MenuBar	Set Preferences	Set Preferences	Einstellungen festlegen	Setjið forstillingar	Imposta preferenze	Установить персональные настройки	Встановити налаштування	Indiquez vos préférences	Cofigurar preferencias	기본 설정	環境設定を設定する	设置偏好


### PR DESCRIPTION
AYAB desktop app lack of recent files feature.
If user for any reason has to reboot program, there is no way to continue work easily, one has to locate file by hand.
It is not convenient and takes time.

This PR adds this feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Recent Files** submenu in the File menu for quick access.
  * The app now tracks recently opened files and automatically updates the submenu (up to 5 items), hiding unavailable entries.
  * Choosing a recent item opens it and refreshes the list.
* **Bug Fixes**
  * Improved recent-menu setup to ensure actions are wired once and the submenu reliably populates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->